### PR TITLE
Improve IDE support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ For an example of traversing the tree inside a HDF5 file see [PrintTree.java](jh
 ## Developing jHDF
 - Clone this repository.
 - Inside the `jhdf` directory run `./gradlew build` (`./gradlew.bat build` on Windows) this will run the build and tests fetching dependencies. 
-- To prepare the project for an IDE run `./gradlew eclipse` for Eclipse, or `./gradlew idea` for IntelliJ. This should create the necessary project files for the project to be imported and setup in the IDE.
+- Import the Gradle project `jhdf` into your IDE
+- Add tests and make changes
 - Once you have made any changes please open a pull request.
 
 To see other available Gradle tasks run `./gradlew tasks` 

--- a/jhdf/.gitignore
+++ b/jhdf/.gitignore
@@ -1,4 +1,5 @@
 /bin/
+/out/
 
 # Gradle
 /.gradle
@@ -9,3 +10,9 @@
 .classpath
 .project
 .pydevproject
+
+# IDEA
+/.idea
+*.iml
+*.ipr
+*.iws

--- a/jhdf/build.gradle
+++ b/jhdf/build.gradle
@@ -15,8 +15,6 @@ plugins {
     // Core plugins
 	id 'java-library'
     id 'jacoco' // Code coverage
-    id 'eclipse' // To create eclipse project
-    id 'idea' // To create InteliJ project
     id 'maven-publish' // For the artifact collections to publish
     id 'signing' // For GPG signing artifacts
     id 'checkstyle' // Code style checks
@@ -65,12 +63,17 @@ test {
 }
 
 def getGitHash = { ->
-    def stdout = new ByteArrayOutputStream()
-    exec {
-        commandLine 'git', 'rev-parse', '--verify', 'HEAD'
-        standardOutput = stdout
+    try {
+        def stdout = new ByteArrayOutputStream()
+        exec {
+            commandLine 'git', 'rev-parse', '--verify', 'HEAD'
+            standardOutput = stdout
+        }
+        return stdout.toString().trim()
+    } catch (Exception e) {
+        // Can happen if git is unavailable
+        return "UNAVALIABLE"
     }
-    return stdout.toString().trim()
 }
 
 jar {


### PR DESCRIPTION
Removes Eclipse and IDEA plugins it is actually better to use the built
in Gradle project import.

Add /.idea to gitignore

Handles the case where git is not available. Would previously cause
import to fail.

Update README.md