### PR TITLE
Configure CheckStyle to use Unix line endings

### DIFF
--- a/jhdf/config/checkstyle/checkstyle.xml
+++ b/jhdf/config/checkstyle/checkstyle.xml
@@ -7,7 +7,9 @@
 <!-- Checkstyle configuration -->
 <module name="Checker">
     <!-- http://checkstyle.sourceforge.net/config_misc.html#NewlineAtEndOfFile -->
-    <module name="NewlineAtEndOfFile"/>
+    <module name="NewlineAtEndOfFile">
+        <property name="lineSeparator" value="lf"/>
+    </module>
     <!-- http://checkstyle.sourceforge.net/config_regexp.html#RegexpSingleline -->
     <module name="RegexpSingleline">
         <!-- \s matches whitespace character, $ matches end of line. -->


### PR DESCRIPTION
Allows 'gradle check' to pass on Windows