### PR TITLE
adding precision 8 for bitfields

### DIFF
--- a/jhdf/src/main/java/io/jhdf/object/datatype/BitField.java
+++ b/jhdf/src/main/java/io/jhdf/object/datatype/BitField.java
@@ -12,6 +12,8 @@ package io.jhdf.object.datatype;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+import io.jhdf.exceptions.HdfTypeException;
+
 public class BitField extends DataType implements OrderedDataType {
     private final ByteOrder order;
     private final boolean lowPadding;
@@ -58,6 +60,13 @@ public class BitField extends DataType implements OrderedDataType {
 
     @Override
     public Class<?> getJavaType() {
-        return boolean.class;
+        switch (bitPrecision) {
+        case 8: 
+            return byte.class;
+        case 1:
+            return boolean.class;
+        default:
+            throw new HdfTypeException("Unsupported bitfield data precision");
+        }
     }
 }

--- a/jhdf/src/main/java/io/jhdf/object/datatype/BitField.java
+++ b/jhdf/src/main/java/io/jhdf/object/datatype/BitField.java
@@ -61,7 +61,7 @@ public class BitField extends DataType implements OrderedDataType {
     @Override
     public Class<?> getJavaType() {
         switch (bitPrecision) {
-        case 8: 
+        case 8:
             return byte.class;
         case 1:
             return boolean.class;


### PR DESCRIPTION
Proposing to add precision 8 for the bitfileds.
It turns out that in addition to previously added boolean bitfields, there is also bitfields with one-byte (8bit) precision, essentially turning bitfields into byte-arrays.