### PR TITLE
NIO Path support

### DIFF
--- a/jhdf/src/main/java/io/jhdf/AbstractNode.java
+++ b/jhdf/src/main/java/io/jhdf/AbstractNode.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.nio.ByteBuffer;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -133,6 +134,11 @@ public abstract class AbstractNode implements Node {
 	public File getFile() {
 		// Recurse back up to the file
 		return getParent().getFile();
+	}
+
+	@Override
+	public Path getFileAsPath() {
+		return getParent().getFileAsPath();
 	}
 
 	@Override

--- a/jhdf/src/main/java/io/jhdf/GroupImpl.java
+++ b/jhdf/src/main/java/io/jhdf/GroupImpl.java
@@ -286,7 +286,7 @@ public class GroupImpl extends AbstractNode implements Group {
 			return ((Group) child).getByPath(pathElements[1]);
 		} else {
 			// Path can't be resolved
-			throw new HdfInvalidPathException(getPath() + path, getFile());
+			throw new HdfInvalidPathException(getPath() + path, getFileAsPath());
 		}
 
 	}
@@ -300,7 +300,7 @@ public class GroupImpl extends AbstractNode implements Group {
 		if (node instanceof Dataset) {
 			return (Dataset) node;
 		} else {
-			throw new HdfInvalidPathException(getPath() + path, getFile());
+			throw new HdfInvalidPathException(getPath() + path, getFileAsPath());
 		}
 	}
 

--- a/jhdf/src/main/java/io/jhdf/api/Node.java
+++ b/jhdf/src/main/java/io/jhdf/api/Node.java
@@ -12,6 +12,7 @@ package io.jhdf.api;
 import io.jhdf.HdfFile;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Map;
 
 /**
@@ -76,11 +77,20 @@ public interface Node {
 	boolean isGroup();
 
 	/**
-	 * Gets the {@link File} object containing this {@link Node}.
+	 * Gets the {@link File} object containing this {@link Node}.<br/>
+	 * <br/>
+	 * Call {@link #getFileAsPath()} instead if the file does not reside in the default file system.
 	 *
 	 * @return the file containing this node
 	 */
 	File getFile();
+
+	/**
+	 * Gets the {@link Path} object containing this {@link Node}.
+	 *
+	 * @return the file containing this node
+	 */
+	Path getFileAsPath();
 
 	/**
 	 * Gets the parent {@link HdfFile} of this node can be useful if you want to

--- a/jhdf/src/main/java/io/jhdf/dataset/NoParent.java
+++ b/jhdf/src/main/java/io/jhdf/dataset/NoParent.java
@@ -17,6 +17,7 @@ import io.jhdf.api.Node;
 import io.jhdf.api.NodeType;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -95,6 +96,11 @@ public enum NoParent implements Group {
 
 	@Override
 	public File getFile() {
+		throw new UnsupportedOperationException(UNKNOWN_GROUP);
+	}
+
+	@Override
+	public Path getFileAsPath() {
 		throw new UnsupportedOperationException(UNKNOWN_GROUP);
 	}
 

--- a/jhdf/src/main/java/io/jhdf/exceptions/HdfInvalidPathException.java
+++ b/jhdf/src/main/java/io/jhdf/exceptions/HdfInvalidPathException.java
@@ -10,6 +10,8 @@
 package io.jhdf.exceptions;
 
 import java.io.File;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
 
 /**
  * Thrown when a path inside a HDF5 file is invalid. It may contain invalid
@@ -22,10 +24,10 @@ public class HdfInvalidPathException extends HdfException {
 	private static final long serialVersionUID = 1L;
 
 	private final String path;
-	private final File file;
+	private final Path   file;
 
-	public HdfInvalidPathException(String path, File file) {
-		super("The path '" + path + "' could not be found in the HDF5 file '" + file.getAbsolutePath() + "'");
+	public HdfInvalidPathException(String path, Path file) {
+		super("The path '" + path + "' could not be found in the HDF5 file '" + file.toAbsolutePath() + "'");
 		this.path = path;
 		this.file = file;
 	}
@@ -35,7 +37,10 @@ public class HdfInvalidPathException extends HdfException {
 	}
 
 	public File getFile() {
-		return file;
+		return file.getFileSystem() == FileSystems.getDefault() ? file.toFile() : null;
 	}
 
+	public Path getFileAsPath() {
+		return file;
+	}
 }

--- a/jhdf/src/main/java/io/jhdf/links/AbstractLink.java
+++ b/jhdf/src/main/java/io/jhdf/links/AbstractLink.java
@@ -19,6 +19,7 @@ import io.jhdf.exceptions.HdfException;
 import org.apache.commons.lang3.concurrent.LazyInitializer;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Map;
 
 /**
@@ -75,6 +76,11 @@ public abstract class AbstractLink implements Link {
 	@Override
 	public File getFile() {
 		return parent.getFile();
+	}
+
+	@Override
+	public Path getFileAsPath() {
+		return parent.getFileAsPath();
 	}
 
 	@Override

--- a/jhdf/src/main/java/io/jhdf/links/ExternalLink.java
+++ b/jhdf/src/main/java/io/jhdf/links/ExternalLink.java
@@ -16,6 +16,7 @@ import io.jhdf.exceptions.HdfBrokenLinkException;
 import org.apache.commons.lang3.concurrent.LazyInitializer;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 /**
@@ -47,14 +48,14 @@ public class ExternalLink extends AbstractLink {
 			return externalFile.getByPath(targetPath);
 		}
 
-		private File getTargetFile() {
+		private Path getTargetFile() {
 			// Check if the target file path is absolute
 			if (targetFile.startsWith(File.separator)) {
-				return Paths.get(targetFile).toFile();
+				return Paths.get(targetFile);
 			} else {
 				// Need to resolve the full path
-				String absolutePathOfThisFilesDirectory = parent.getFile().getParent();
-				return Paths.get(absolutePathOfThisFilesDirectory, targetFile).toFile();
+				Path thisFilesDirectory = parent.getFileAsPath().getParent();
+				return thisFilesDirectory.resolve(targetFile);
 			}
 		}
 	}

--- a/jhdf/src/test/java/io/jhdf/nio/NioPathTest.java
+++ b/jhdf/src/test/java/io/jhdf/nio/NioPathTest.java
@@ -1,0 +1,251 @@
+package io.jhdf.nio;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.jhdf.HdfFile;
+import io.jhdf.api.*;
+import io.jhdf.exceptions.HdfException;
+import io.jhdf.object.datatype.DataType;
+
+/**
+ * This test ensures that jHDF supports loading HDF5 files referenced by instances of {@link java.nio.file.Path}
+ * that do not reside in the default file system. To do so, the test
+ * <ol>
+ *     <li>
+ *         copies all test files into a temporary {@code ZipFileSystem} and
+ *     </li>
+ *     <li>
+ *         evaluates that loading the local file and loading the non-local copy yields the same HDF5 structure representation.
+ *     </li>
+ * </ol>
+ */
+class NioPathTest
+{
+	private static final String	HDF5_TEST_FILE_DIRECTORY_PATH	= "/hdf5";
+	private static final String	ZIP_FILE_NAME					= "nio_test.zip";
+	private static Path			TEMP_DIR;
+	private static Path			LOCAL_ROOT_DIRECTORY;
+	private static URI			NON_LOCAL_ROOT_DIRECTORY_URI;
+
+	@BeforeAll
+	static void setup() throws IOException {
+		LOCAL_ROOT_DIRECTORY = getPathToResource(HDF5_TEST_FILE_DIRECTORY_PATH);
+		TEMP_DIR = Files.createTempDirectory("jHDF_NIO_test");
+		Path zipFile = TEMP_DIR.resolve(ZIP_FILE_NAME);
+		try (FileSystem zipFileSystem = createZipFileSystem(zipFile)) {
+			Path nonLocalRootDirectory = zipFileSystem.getPath("/");
+			NON_LOCAL_ROOT_DIRECTORY_URI = nonLocalRootDirectory.toUri();
+			copyFiles(LOCAL_ROOT_DIRECTORY, nonLocalRootDirectory);
+		}
+	}
+
+	@AfterAll
+	static void shutdown() throws IOException {
+		if (TEMP_DIR != null && Files.isDirectory(TEMP_DIR)) {
+			delete(TEMP_DIR);
+		}
+	}
+
+	@ParameterizedTest
+	@MethodSource("getTestFileNames")
+	void testNonDefaultFileSystemAccess(String testFileName) throws IOException {
+		Path localTestFile = LOCAL_ROOT_DIRECTORY.resolve(testFileName);
+		try (FileSystem ignored = openZipFileSystem(NON_LOCAL_ROOT_DIRECTORY_URI)) {
+			Path nonLocalRootDirectory = Paths.get(NON_LOCAL_ROOT_DIRECTORY_URI);
+			Path nonLocalTestFile = nonLocalRootDirectory.resolve(testFileName);
+			compareStructure(localTestFile, nonLocalTestFile);
+		}
+	}
+
+	private void compareStructure(Path file1, Path file2) {
+		HdfFile hdfFile1 = new HdfFile(file1);
+		HdfFile hdfFile2 = new HdfFile(file2);
+		compareNodes(hdfFile1, hdfFile2);
+	}
+
+	private void compareNodes(Node node1, Node node2) {
+		assertEquals(node1.getName(), node2.getName(), "Deviating node names");
+		String errorSuffix = " of nodes '" + node1.getName() + "'";
+
+		assertEquals(node1.getPath(), node2.getPath(), "Deviating paths" + errorSuffix);
+		assertEquals(node1.isLink(), node2.isLink(), "Deviating isLink flags" + errorSuffix);
+
+		boolean brokenLink = node1.isLink() && ((Link) node1).isBrokenLink();
+
+		if (!brokenLink) {
+			// the following checks lead to exceptions for broken links
+			assertEquals(node1.getType(), node2.getType(), "Deviating types" + errorSuffix);
+			assertEquals(node1.isGroup(), node2.isGroup(), "Deviating isGroup flags" + errorSuffix);
+			assertEquals(node1.getAddress(), node2.getAddress(), "Deviating addresses" + errorSuffix);
+			assertEquals(node1.isAttributeCreationOrderTracked(), node2.isAttributeCreationOrderTracked(), "Deviating isAttributeCreationOrderTracked flags" + errorSuffix);
+
+			Map<String, Attribute> attributes1 = node1.getAttributes();
+			Map<String, Attribute> attributes2 = node2.getAttributes();
+			assertEquals(attributes1.size(), attributes2.size(), "Deviating number of attributes" + errorSuffix);
+			for (String attributeName : attributes1.keySet()) {
+				assertTrue(attributes2.containsKey(attributeName), "Missing attribute '" + attributeName + "' in second node '" + node2.getName() + "'");
+				Attribute attribute1 = attributes1.get(attributeName);
+				Attribute attribute2 = attributes2.get(attributeName);
+				compareAttributes(attribute1, attribute2);
+			}
+		}
+
+		if (node1 instanceof Link) {
+			assertTrue(node2 instanceof Link, "Node '" + node2.getName() + "' is not a link");
+			compareLinks((Link) node1, (Link) node2);
+		} else if (node1 instanceof Group) {
+			assertTrue(node2 instanceof Group, "Node '" + node2.getName() + "' is not a group");
+			compareGroups((Group) node1, (Group) node2);
+		} else if (node1 instanceof Dataset) {
+			assertTrue(node2 instanceof Dataset, "Node '" + node2.getName() + "' is not a dataset");
+			compareDatasets((Dataset) node1, (Dataset) node2);
+		}
+	}
+
+	private void compareAttributes(Attribute attribute1, Attribute attribute2) {
+		assertEquals(attribute1.getName(), attribute2.getName(), "Deviating attribute names");
+		String errorSuffix = " of attributes '" + attribute1.getName() + "'";
+
+		assertEquals(attribute1.getSize(), attribute2.getSize(), "Deviating sizes" + errorSuffix);
+		assertEquals(attribute1.getSizeInBytes(), attribute2.getSizeInBytes(), "Deviating sizes in bytes" + errorSuffix);
+		assertArrayEquals(attribute1.getDimensions(), attribute2.getDimensions(), "Deviating dimensions" + errorSuffix);
+		assertEquals(attribute1.getJavaType(), attribute2.getJavaType(), "Deviating Java types" + errorSuffix);
+		assertEquals(attribute1.isScalar(), attribute2.isScalar(), "Deviating isScalar flags" + errorSuffix);
+		assertEquals(attribute1.isEmpty(), attribute2.isEmpty(), "Deviating isScalar flags" + errorSuffix);
+	}
+
+	private void compareLinks(Link link1, Link link2) {
+		String errorSuffix = " of links '" + link1.getName() + "'";
+
+		assertEquals(link1.getTargetPath(), link2.getTargetPath(), "Deviating target paths" + errorSuffix);
+		assertEquals(link1.isBrokenLink(), link2.isBrokenLink(), "Deviating isBrokenLink flags" + errorSuffix);
+	}
+
+	private void compareGroups(Group group1, Group group2) {
+		String errorSuffix = " of groups '" + group1.getName() + "'";
+
+		assertEquals(group1.isLinkCreationOrderTracked(), group2.isLinkCreationOrderTracked(), "Deviating isLinkCreationOrderTracked flags" + errorSuffix);
+
+		Map<String, Node> children1 = group1.getChildren();
+		Map<String, Node> children2 = group2.getChildren();
+		assertEquals(children1.size(), children2.size(), "Deviating number of children" + errorSuffix);
+		for (String childName : children1.keySet()) {
+			assertTrue(children2.containsKey(childName), "Missing child '" + childName + "' in second group '" + group2.getName() + "'");
+			Node child1 = children1.get(childName);
+			Node child2 = children2.get(childName);
+			compareNodes(child1, child2);
+		}
+	}
+
+	private void compareDatasets(Dataset dataset1, Dataset dataset2) {
+		String errorSuffix = " of datasets '" + dataset1.getName() + "'";
+
+		assertEquals(dataset1.getSize(), dataset2.getSize(), "Deviating sizes" + errorSuffix);
+		assertEquals(dataset1.getSizeInBytes(), dataset2.getSizeInBytes(), "Deviating sizes in bytes" + errorSuffix);
+		assertEquals(dataset1.getStorageInBytes(), dataset2.getStorageInBytes(), "Deviating storage sizes in bytes" + errorSuffix);
+		assertArrayEquals(dataset1.getDimensions(), dataset2.getDimensions(), "Deviating dimensions" + errorSuffix);
+		assertEquals(dataset1.isScalar(), dataset2.isScalar(), "Deviating isScalar flags" + errorSuffix);
+		assertEquals(dataset1.isEmpty(), dataset2.isEmpty(), "Deviating isScalar flags" + errorSuffix);
+		assertEquals(dataset1.isCompound(), dataset2.isCompound(), "Deviating isCompound flags" + errorSuffix);
+		assertEquals(dataset1.isVariableLength(), dataset2.isVariableLength(), "Deviating isVariableLength flags" + errorSuffix);
+		assertArrayEquals(dataset1.getMaxSize(), dataset2.getMaxSize(), "Deviating max sizes" + errorSuffix);
+		assertEquals(dataset1.getDataLayout(), dataset2.getDataLayout(), "Deviating data layouts" + errorSuffix);
+		assertEquals(dataset1.getJavaType(), dataset2.getJavaType(), "Deviating Java type" + errorSuffix);
+
+		Object fillValue1 = null;
+		boolean fillValueExists;
+		try {
+			fillValue1 = dataset1.getFillValue();
+			fillValueExists = true;
+		} catch (HdfException e) {
+			fillValueExists = false;
+		}
+		if (fillValueExists) {
+			assertEquals(fillValue1, dataset2.getFillValue(), "Deviating fill values" + errorSuffix);
+		}
+
+		DataType dataType1 = dataset1.getDataType();
+		DataType dataType2 = dataset2.getDataType();
+		compareDataTypes(dataType1, dataType2, errorSuffix);
+	}
+
+	private void compareDataTypes(DataType dataType1, DataType dataType2, String errorSuffix) {
+		assertEquals(dataType1.getVersion(), dataType2.getVersion(), "Deviating data type versions" + errorSuffix);
+		assertEquals(dataType1.getDataClass(), dataType2.getDataClass(), "Deviating data type data classes" + errorSuffix);
+		assertEquals(dataType1.getSize(), dataType2.getSize(), "Deviating data type sizes" + errorSuffix);
+		assertEquals(dataType1.getJavaType(), dataType2.getJavaType(), "Deviating data type Java classes" + errorSuffix);
+	}
+
+	static List<String> getTestFileNames() throws IOException {
+		List<String> testFileNames = new ArrayList<>();
+		try (DirectoryStream<Path> stream = Files.newDirectoryStream(LOCAL_ROOT_DIRECTORY)) {
+			for (Path sourceFile : stream) {
+				if (Files.isRegularFile(sourceFile)) {
+					testFileNames.add(sourceFile.getFileName().toString());
+				}
+			}
+		}
+		return testFileNames;
+	}
+
+	private static void delete(Path path) throws IOException {
+		if (Files.isDirectory(path)) {
+			try (DirectoryStream<Path> stream = Files.newDirectoryStream(path)) {
+				for (Path value : stream) {
+					delete(value);
+				}
+			}
+		}
+		Files.delete(path);
+	}
+
+	private static void copyFiles(Path sourceDirectory, Path targetDirectory) throws IOException {
+		try (DirectoryStream<Path> stream = Files.newDirectoryStream(sourceDirectory)) {
+			for (Path sourceFile : stream) {
+				if (Files.isRegularFile(sourceFile)) {
+					Path targetFile = targetDirectory.resolve(sourceFile.getFileName().toString());
+					Files.copy(sourceFile, targetFile);
+				}
+			}
+		}
+	}
+
+	private static Path getPathToResource(String relativePath) {
+		URL testFileDirectoryUrl = NioPathTest.class.getResource(relativePath);
+		if (testFileDirectoryUrl == null) {
+			throw new IllegalStateException("No resource URL available for relative path '" + relativePath + "'");
+		}
+		try {
+			return Paths.get(testFileDirectoryUrl.toURI());
+		} catch (URISyntaxException e) {
+			throw new IllegalStateException("Invalid resource URL '" + testFileDirectoryUrl + "'");
+		}
+	}
+
+	private static FileSystem createZipFileSystem(Path zipFile) throws IOException {
+		URI zipFileUri = zipFile.toUri();
+		URI zipUri = URI.create("jar:" + zipFileUri);
+		return openZipFileSystem(zipUri);
+	}
+
+	private static FileSystem openZipFileSystem(URI uri) throws IOException {
+		Map<String, String> env = new HashMap<>();
+		env.put("create", "true");
+		return FileSystems.newFileSystem(uri, env);
+	}
+}


### PR DESCRIPTION
jHDF makes intensive use of NIO internally and HdfFile provides constructors for Path and URI. However, these constructors convert Path and URI to File (before converting it back to Path again). In this branch, all internal usages of File have been replaced with Path.

Remarks:
* The test NioPathTest demonstrates that all provided test files can be loaded correctly from within a ZipFileSystem.
* I did not want to break with the API, so I had to add a method Node.getFileAsPath() as an alternative to Node.getFile() that returns a Path instance rather than a File instance. (Unfortunately, the name "getPath" was already in use.)
* I had to implement a fallback strategy in HdfFileChannel when memory mapping is not supported by the file system, which is the case for all non-default file systems I am aware of. This fallback only works if the requested buffer size does not exceed Integer.MAX_VALUE.