### PR TITLE
Fix: thread safety of FileChannelFromSeekableByteChannel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # jHDF Change Log
 
+## v0.9.4 - April 2025
+- Fix: thread-safety of FileChannelFromSeekableByteChannel added via ReentrantLock
+- Add: `HdfFile(FileChannel chennel)` constructor for custom FileChannel providers
+
 ## v0.9.3 - April 2025
 - Add support for slicing of chunked datasets. This allows accessing portions of large, chunked datasets using `getData(offset, length)`. Thanks to @thomas-reimonn https://github.com/jamesmudd/jhdf/issues/52
 - Add constructor to open an `HdfFile(URL url)` to support streaming reading of remote HDF5 files. Thanks to @thomas-reimonn

--- a/jhdf/build.gradle
+++ b/jhdf/build.gradle
@@ -27,7 +27,7 @@ plugins {
 
 // Variables
 group = 'io.jhdf'
-version = '0.9.3'
+version = '0.9.4'
 
 compileJava {
     sourceCompatibility = "1.8"

--- a/jhdf/src/main/java/io/jhdf/HdfFile.java
+++ b/jhdf/src/main/java/io/jhdf/HdfFile.java
@@ -349,6 +349,53 @@ public class HdfFile implements Group, AutoCloseable {
 		}
 	}
 
+	/**
+	 * Opens an HDF5 file from a FileChannel, which can be used for
+	 * remote or local file access.
+	 *
+	 * @param channel   The FileChannel for reading the HDF5 file. This must be thread-safe.
+	 * @throws HdfException If the HDF5 file could not be opened or if it's not valid.
+	 */
+	public HdfFile(FileChannel channel) {
+		FileChannel fc = channel;
+		try {
+			// Validate HDF5 signature
+			boolean validSignature = false;
+			long offset;
+			for (offset = 0; offset < fc.size(); offset = nextOffset(offset)) {
+				logger.trace("Checking for signature at offset = {}", offset);
+				validSignature = Superblock.verifySignature(fc, offset);
+				if (validSignature) {
+					logger.debug("Found valid signature at offset = {}", offset);
+					break;
+				}
+			}
+			if (!validSignature) {
+				throw new HdfException("No valid HDF5 signature found in remote file");
+			}
+
+			Superblock superblock = Superblock.readSuperblock(fc, offset);
+			if (superblock.getBaseAddressByte() != offset) {
+				throw new HdfException("Invalid superblock base address detected in remote file");
+			}
+
+			hdfBackingStorage = new HdfFileChannel(fc, superblock);
+
+			if (superblock instanceof SuperblockV0V1) {
+				SuperblockV0V1 sb = (SuperblockV0V1) superblock;
+				SymbolTableEntry ste = new SymbolTableEntry(hdfBackingStorage, sb.getRootGroupSymbolTableAddress() - sb.getBaseAddressByte());
+				this.rootGroup = GroupImpl.createRootGroup(hdfBackingStorage, ste.getObjectHeaderAddress(), this);
+			} else if (superblock instanceof SuperblockV2V3) {
+				SuperblockV2V3 sb = (SuperblockV2V3) superblock;
+				this.rootGroup = GroupImpl.createRootGroup(hdfBackingStorage, sb.getRootGroupObjectHeaderAddress(), this);
+			} else {
+				throw new HdfException("Unsupported superblock version: " + superblock.getVersionOfSuperblock());
+			}
+
+		} catch (IOException e) {
+			throw new HdfException("Failed to open HdfFile from FileChannel", e);
+		}
+	}
 
 	public static WritableHdfFile write(Path path) {
 		return new WritableHdfFile(path);

--- a/jhdf/src/main/java/io/jhdf/HdfFile.java
+++ b/jhdf/src/main/java/io/jhdf/HdfFile.java
@@ -357,6 +357,7 @@ public class HdfFile implements Group, AutoCloseable {
 	 * @throws HdfException If the HDF5 file could not be opened or if it's not valid.
 	 */
 	public HdfFile(FileChannel channel) {
+		this.optionalFile = Optional.empty();
 		try {
 			// Validate HDF5 signature
 			boolean validSignature = false;

--- a/jhdf/src/main/java/io/jhdf/nio/FileChannelFromSeekableByteChannel.java
+++ b/jhdf/src/main/java/io/jhdf/nio/FileChannelFromSeekableByteChannel.java
@@ -19,14 +19,15 @@ import java.nio.channels.FileLock;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.channels.WritableByteChannel;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Wraps a {@link SeekableByteChannel} within a {@link FileChannel}
  */
-public class FileChannelFromSeekableByteChannel extends FileChannel
-{
+public class FileChannelFromSeekableByteChannel extends FileChannel {
 	private static final int MAX_TRANSFER_SIZE = 8192;
-	private final SeekableByteChannel	delegate;
+	private final SeekableByteChannel delegate;
+	private final ReentrantLock lock = new ReentrantLock(true);
 
 	public FileChannelFromSeekableByteChannel(SeekableByteChannel delegate) {
 		this.delegate = delegate;
@@ -34,91 +35,141 @@ public class FileChannelFromSeekableByteChannel extends FileChannel
 
 	@Override
 	public int read(ByteBuffer dst) throws IOException {
-		return delegate.read(dst);
+		lock.lock();
+		try {
+			return delegate.read(dst);
+		} finally {
+			lock.unlock();
+		}
 	}
 
 	@Override
 	public int read(ByteBuffer dst, long position) throws IOException {
-		checkAccess(position);
-		long originalPosition = delegate.position();
+		lock.lock();
 		try {
-			delegate.position(position);
-			return delegate.read(dst);
+			checkAccess(position);
+			long originalPosition = delegate.position();
+			try {
+				delegate.position(position);
+				return delegate.read(dst);
+			} finally {
+				delegate.position(originalPosition);
+			}
 		} finally {
-			delegate.position(originalPosition);
+			lock.unlock();
 		}
 	}
 
 	@Override
 	public long read(ByteBuffer[] dsts, int offset, int length) throws IOException {
-		int totalBytesRead = 0;
-		for (int i = offset; i < offset + length; i++) {
-			ByteBuffer dst = dsts[i];
-			int bytesRead = read(dst);
-			if (bytesRead == -1) {
-				return totalBytesRead > 0 ? totalBytesRead : -1;
+		lock.lock();
+		try {
+			int totalBytesRead = 0;
+			for (int i = offset; i < offset + length; i++) {
+				ByteBuffer dst = dsts[i];
+				int bytesRead = read(dst);
+				if (bytesRead == -1) {
+					return totalBytesRead > 0 ? totalBytesRead : -1;
+				}
+				totalBytesRead += bytesRead;
+				if (dst.hasRemaining()) {
+					// For some reason the buffer has not been filled completely. This is a valid state in which we may return.
+					break;
+				}
 			}
-			totalBytesRead += bytesRead;
-			if  (dst.hasRemaining()) {
-				// For some reason the buffer has not been filled completely. This is a valid state in which we may return.
-				break;
-			}
+			return totalBytesRead;
+		} finally {
+			lock.unlock();
 		}
-		return totalBytesRead;
 	}
 
 	@Override
 	public int write(ByteBuffer src) throws IOException {
-		return delegate.write(src);
+		lock.lock();
+		try {
+			return delegate.write(src);
+		} finally {
+			lock.unlock();
+		}
 	}
 
 	@Override
 	public int write(ByteBuffer src, long position) throws IOException {
-		checkAccess(position);
-		long originalPosition = delegate.position();
+		lock.lock();
 		try {
-			delegate.position(position);
-			return delegate.write(src);
+			checkAccess(position);
+			long originalPosition = delegate.position();
+			try {
+				delegate.position(position);
+				return delegate.write(src);
+			} finally {
+				delegate.position(originalPosition);
+			}
 		} finally {
-			delegate.position(originalPosition);
+			lock.unlock();
 		}
 	}
 
 	@Override
 	public long write(ByteBuffer[] srcs, int offset, int length) throws IOException {
-		int totalBytesWritten = 0;
-		for (int i = offset; i < offset + length; i++) {
-			ByteBuffer src = srcs[i];
-			int bytesWritten = write(src);
-			totalBytesWritten += bytesWritten;
-			if (src.hasRemaining()) {
-				// For some reason the buffer has not been written completely. This is a valid state in which we may return.
-				break;
+		lock.lock();
+		try {
+			int totalBytesWritten = 0;
+			for (int i = offset; i < offset + length; i++) {
+				ByteBuffer src = srcs[i];
+				int bytesWritten = write(src);
+				totalBytesWritten += bytesWritten;
+				if (src.hasRemaining()) {
+					// For some reason the buffer has not been written completely. This is a valid state in which we may return.
+					break;
+				}
 			}
+			return totalBytesWritten;
+		} finally {
+			lock.unlock();
 		}
-		return totalBytesWritten;
 	}
 
 	@Override
 	public long position() throws IOException {
-		return delegate.position();
+		lock.lock();
+		try {
+			return delegate.position();
+		} finally {
+			lock.unlock();
+		}
 	}
 
 	@Override
 	public FileChannel position(long newPosition) throws IOException {
-		delegate.position(newPosition);
-		return this;
+		lock.lock();
+		try {
+			delegate.position(newPosition);
+			return this;
+		} finally {
+			lock.unlock();
+		}
 	}
 
 	@Override
 	public long size() throws IOException {
-		return delegate.size();
+		lock.lock();
+		try {
+			return delegate.size();
+		} finally {
+			lock.unlock();
+		}
 	}
 
 	@Override
 	public FileChannel truncate(long size) throws IOException {
-		delegate.truncate(size);
-		return this;
+		lock.lock();
+		try {
+			delegate.truncate(size);
+			return this;
+		} finally {
+			lock.unlock();
+		}
 	}
 
 	@Override
@@ -128,105 +179,130 @@ public class FileChannelFromSeekableByteChannel extends FileChannel
 
 	@Override
 	public long transferTo(long position, long count, WritableByteChannel target) throws IOException {
-		checkTransfer(position, count, target);
-		long size = size();
-		if (count == 0 || position >= size) {
-			// nothing to do
-			return 0;
+		lock.lock();
+		try {
+			checkTransfer(position, count, target);
+			long size = size();
+			if (count == 0 || position >= size) {
+				// nothing to do
+				return 0;
+			}
+			if (position + count > size) {
+				// don't transfer more bytes than available
+				count = size - position;
+			}
+			return transferData(delegate, target, position, count);
+		} finally {
+			lock.unlock();
 		}
-		if (position + count > size) {
-			// don't transfer more bytes than available
-			count = size - position;
-		}
-		return transferData(delegate, target, position, count);
 	}
 
 	@Override
 	public long transferFrom(ReadableByteChannel src, long position, long count) throws IOException {
-		checkTransfer(position, count, src);
-		long size = size();
-		if (count == 0 || position > size) {
-			// nothing to do
-			return 0;
+		lock.lock();
+		try {
+			checkTransfer(position, count, src);
+			long size = size();
+			if (count == 0 || position > size) {
+				// nothing to do
+				return 0;
+			}
+			return transferData(src, delegate, position, count);
+		} finally {
+			lock.unlock();
 		}
-		return transferData(src, delegate, position, count);
 	}
 
 	private void checkTransfer(long position, long count, Channel other) throws ClosedChannelException {
-		if (!other.isOpen()) {
-			throw new ClosedChannelException();
-		}
-		checkAccess(position);
-		if (count < 0) {
-			throw new IllegalArgumentException("Count must be non-negative");
+		lock.lock();
+		try {
+			if (!other.isOpen()) {
+				throw new ClosedChannelException();
+			}
+			checkAccess(position);
+			if (count < 0) {
+				throw new IllegalArgumentException("Count must be non-negative");
+			}
+		} finally {
+			lock.unlock();
 		}
 	}
 
 	private void checkAccess(long position) throws ClosedChannelException {
-		if (!isOpen()) {
-			throw new ClosedChannelException();
-		}
-		if (position < 0) {
-			throw new IllegalArgumentException("Position must be non-negative");
+		lock.lock();
+		try {
+			if (!isOpen()) {
+				throw new ClosedChannelException();
+			}
+			if (position < 0) {
+				throw new IllegalArgumentException("Position must be non-negative");
+			}
+		} finally {
+			lock.unlock();
 		}
 	}
 
 	private long transferData(ReadableByteChannel src, WritableByteChannel target, long delegateStartPosition, long count) throws IOException {
-		long originalPosition = delegate.position();
-		long totalBytesTransferred = 0;
+		lock.lock();
 		try {
-			int capacity = (int) Math.min(count, MAX_TRANSFER_SIZE);
-			ByteBuffer buffer = ByteBuffer.allocate(capacity);
-			delegate.position(delegateStartPosition);
-			while (totalBytesTransferred < count) {
-				buffer.limit((int) Math.min(count - totalBytesTransferred, MAX_TRANSFER_SIZE));
-				int bytesRead = src.read(buffer);
-				if (bytesRead <= 0) {
-					break;
-				}
-				buffer.flip();
-				int bytesWritten = target.write(buffer);
-				totalBytesTransferred += bytesWritten;
+			long originalPosition = delegate.position();
+			long totalBytesTransferred = 0;
+			try {
+				int capacity = (int) Math.min(count, MAX_TRANSFER_SIZE);
+				ByteBuffer buffer = ByteBuffer.allocate(capacity);
+				delegate.position(delegateStartPosition);
+				while (totalBytesTransferred < count) {
+					buffer.limit((int) Math.min(count - totalBytesTransferred, MAX_TRANSFER_SIZE));
+					int bytesRead = src.read(buffer);
+					if (bytesRead <= 0) {
+						break;
+					}
+					buffer.flip();
+					int bytesWritten = target.write(buffer);
+					totalBytesTransferred += bytesWritten;
 
-				if (bytesWritten != bytesRead) {
-					/*
-					 * We have read more bytes from src than written to target. We must adjust the position
-					 * of src accordingly such that the read, but unwritten bytes are not lost forever.
-					 * If src is the delegate, then its position will be reset anyway.
-					 */
-					if (src != delegate) {
-						long readButUnwrittenBytes = bytesRead - bytesWritten;
-						if (src instanceof SeekableByteChannel) {
-							SeekableByteChannel srcChannel = (SeekableByteChannel) src;
-							srcChannel.position(srcChannel.position() - readButUnwrittenBytes);
-						} else {
-							/*
-							 * We can't adjust the position of src. Hence, we must force
-							 * writing the unwritten bytes.
-							 */
-							while (bytesWritten < bytesRead) {
-								int missingBytesWritten = target.write(buffer);
-								if (missingBytesWritten == 0) {
-									// avoid an infinite loop
-									throw new IOException("Failed to write bytes to position " + delegate.position());
+					if (bytesWritten != bytesRead) {
+						/*
+						 * We have read more bytes from src than written to target. We must adjust the position
+						 * of src accordingly such that the read, but unwritten bytes are not lost forever.
+						 * If src is the delegate, then its position will be reset anyway.
+						 */
+						if (src != delegate) {
+							long readButUnwrittenBytes = bytesRead - bytesWritten;
+							if (src instanceof SeekableByteChannel) {
+								SeekableByteChannel srcChannel = (SeekableByteChannel) src;
+								srcChannel.position(srcChannel.position() - readButUnwrittenBytes);
+							} else {
+								/*
+								 * We can't adjust the position of src. Hence, we must force
+								 * writing the unwritten bytes.
+								 */
+								while (bytesWritten < bytesRead) {
+									int missingBytesWritten = target.write(buffer);
+									if (missingBytesWritten == 0) {
+										// avoid an infinite loop
+										throw new IOException("Failed to write bytes to position " + delegate.position());
+									}
+									bytesWritten += missingBytesWritten;
+									totalBytesTransferred += missingBytesWritten;
 								}
-								bytesWritten += missingBytesWritten;
-								totalBytesTransferred += missingBytesWritten;
 							}
 						}
+						break;
 					}
-					break;
+					buffer.clear();
 				}
-				buffer.clear();
+			} catch (IOException e) {
+				if (totalBytesTransferred == 0) {
+					throw e;
+				}
+			} finally {
+				delegate.position(originalPosition);
 			}
-		} catch (IOException e) {
-			if (totalBytesTransferred == 0) {
-				throw e;
-			}
+			return totalBytesTransferred;
 		} finally {
-			delegate.position(originalPosition);
+			lock.unlock();
 		}
-		return totalBytesTransferred;
 	}
 
 	@Override
@@ -246,6 +322,11 @@ public class FileChannelFromSeekableByteChannel extends FileChannel
 
 	@Override
 	protected void implCloseChannel() throws IOException {
-		delegate.close();
+		lock.lock();
+		try {
+			delegate.close();
+		} finally {
+			lock.unlock();
+		}
 	}
 }


### PR DESCRIPTION
I ran into an issue when reading chunked datasets from a SeekableByteChannel, that I think is due to a thread-safety problem in `FileChannelFromSeekableByteChannel`. Reading chunked datasets uses a fork-join pool for parallel decompression, and multiple threads try to read in parallel. There is a wrapper `FileChannelFromSeekableByteChannel` that provides a FileChannel. FileChannels are supposed to be thread safe, and the the underlying `HttpSeekableByteChannel` is thread-safe. However, the FileChannel doesn't lock on reads.

I think the problem is:
[Thread-1] read(bufferX, positionX) -> sets position to X
[Thread-2] read(bufferY, positionY) -> sets position to Y
[Thread-1] -> copies into bufferX from position Y
[Thread-2] -> copies into bufferY from position Y + bufferX.length

This PR adds a ReentrantLock for the `FileChannelFromSeekableByteChannel`. It also adds a constructor for HdfFile(FileChannel) for user provided FileChannels so that users can provide higher performance implementations of FileChannel. `read(buffer, position)` can handle concurrent access in general, except that it involves altering the position of the underlying byteChannel. A different implementation could allow concurrent reads, and only lock on `read(buffer)`.