### PR TITLE
Add JitPack Java 17 config under jhdf module

### DIFF
--- a/jhdf/jitpack.yml
+++ b/jhdf/jitpack.yml
@@ -1,0 +1,5 @@
+jdk:
+  - openjdk17
+
+install:
+  - ./gradlew clean build publishToMavenLocal -x test -x check


### PR DESCRIPTION
### Motivation
- Ensure JitPack uses Java 17 when it runs Gradle inside the `jhdf/` module so builds no longer fail with `invalid source release: 17`.

### Description
- Add `jhdf/jitpack.yml` that sets `jdk: - openjdk17` and uses the existing install command `./gradlew clean build publishToMavenLocal -x test -x check`.

### Testing
- No automated tests were run as part of this change; CI/JitPack will execute the Gradle build using the new module-level `jitpack.yml`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3f82b112883228356541eef933e99)