### PR TITLE
Switch/update from org.lz4:lz4-java:1.8.0 to at.yawk.lz4:lz4-java:1.11.0

### DIFF
--- a/jhdf/build.gradle
+++ b/jhdf/build.gradle
@@ -55,8 +55,8 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.20.0'
     // lzf compression support
     implementation 'com.ning:compress-lzf:1.1.3'
-    // lz5 support https://mvnrepository.com/artifact/org.lz4/lz4-java
-    implementation 'org.lz4:lz4-java:1.8.0'
+    // lz4 support https://mvnrepository.com/artifact/at.yawk.lz4/lz4-java
+    implementation 'at.yawk.lz4:lz4-java:1.11.0'
 
     // TESTING
     // Use JUnit 5 test framework
@@ -247,7 +247,7 @@ String buildRequireBundleHeader() {
         "slf4j.api": "org.slf4j:slf4j-api",
         "org.apache.commons.lang3": "org.apache.commons:commons-lang3",
         "com.ning.compress-lzf": "com.ning:compress-lzf",
-        "lz4-java": "org.lz4:lz4-java"
+        "lz4-java": "at.yawk.lz4:lz4-java"
     ]
 
     def moduleToVersion = runtimeDependencies.collectEntries {

--- a/jhdf/gradle.lockfile
+++ b/jhdf/gradle.lockfile
@@ -1,6 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+at.yawk.lz4:lz4-java:1.11.0=compileClasspath,jmhCompileClasspath,testCompileClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-annotations:2.21=jmhRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-core:2.21.2=jmhRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-databind:2.21.2=jmhRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
@@ -79,7 +80,6 @@ org.junit.platform:junit-platform-engine:1.13.4=jmhRuntimeClasspath,testRuntimeC
 org.junit.platform:junit-platform-launcher:1.13.4=jmhRuntimeClasspath,testRuntimeClasspath
 org.junit:junit-bom:5.13.4=jmhRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
 org.junit:junit-bom:5.14.0=spotbugs
-org.lz4:lz4-java:1.8.0=compileClasspath,jmhCompileClasspath,jmhRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 org.mockito:mockito-core:5.21.0=jmhRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
 org.objenesis:objenesis:3.0.1=testCompileClasspath
 org.objenesis:objenesis:3.3=jmhRuntimeClasspath,testRuntimeClasspath


### PR DESCRIPTION
lz4-java was moved from org.lz4 to at.yawk.lz4.
Switch and update dependency due to security vulnerabilites.