### PR TITLE
chore: update dependencies and dependency-review GitHub Action

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,4 +17,4 @@ jobs:
       - name: 'Checkout Repository'
         uses: actions/checkout@v6
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v5

--- a/jhdf/build.gradle
+++ b/jhdf/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     implementation 'org.slf4j:slf4j-api:2.0.17'
     implementation 'org.apache.commons:commons-lang3:3.20.0'
     // lzf compression support
-    implementation 'com.ning:compress-lzf:1.1.3'
+    implementation 'com.ning:compress-lzf:1.2.0'
     // lz4 support https://mvnrepository.com/artifact/at.yawk.lz4/lz4-java
     implementation 'at.yawk.lz4:lz4-java:1.11.0'
 
@@ -67,7 +67,7 @@ dependencies {
     testRuntimeOnly 'org.slf4j:slf4j-simple:2.0.17'
 
     // Mocking
-    testImplementation 'org.mockito:mockito-core:5.21.0'
+    testImplementation 'org.mockito:mockito-core:5.23.0'
     testImplementation 'org.powermock:powermock-core:2.0.9'
 
     // Matchers
@@ -77,8 +77,8 @@ dependencies {
     // Alternative bitshuffle impl to check results against
     testImplementation 'org.xerial.snappy:snappy-java:1.1.10.8'
     // For parsing h5dump XML output
-    testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.21.2'
-    testImplementation 'commons-io:commons-io:2.21.0'
+    testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.21.3'
+    testImplementation 'commons-io:commons-io:2.22.0'
     // For a FileSystemProvider implementation without FileChannel support
     testImplementation 'com.google.jimfs:jimfs:1.3.1'
 }


### PR DESCRIPTION
### Motivation
- Refresh a handful of project dependencies and the dependency-review GH Action to keep the project secure and up-to-date while preserving Java 17 support. 
- Avoid introducing unstable pre-release tool versions to maintain build stability.

### Description
- Bumped `com.ning:compress-lzf` from `1.1.3` to `1.2.0` in `jhdf/build.gradle`.
- Bumped `org.mockito:mockito-core` from `5.21.0` to `5.23.0` and `com.fasterxml.jackson.dataformat:jackson-dataformat-xml` from `2.21.2` to `2.21.3` and `commons-io:commons-io` from `2.21.0` to `2.22.0` in `jhdf/build.gradle`.
- Updated the Dependency Review GitHub Action usage from `actions/dependency-review-action@v4` to `actions/dependency-review-action@v5` in `.github/workflows/dependency-review.yml`.
- Left Java compatibility settings unchanged (`sourceCompatibility`/`targetCompatibility` remain `17`) and updated dependency locks via a lock file write.

### Testing
- Ran `./gradlew test --write-locks` from the `jhdf/` directory to update locks and exercise the full test suite, and the build/tests completed successfully. 
- The Gradle test run produced a full test report with tests passing under the current dependency set and Java 17 configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0830d825cc8322ad690261a46ae694)