### PR TITLE
ci: conditionally run SonarQube job only when `SONAR_TOKEN` is set

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
     sonarqube:
+        if: ${{ secrets.SONAR_TOKEN != '' }}
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6


### PR DESCRIPTION
### Motivation
- Prevent the SonarQube GitHub Actions job from running (and potentially failing) when the `SONAR_TOKEN` secret is not configured.

### Description
- Add `if: ${{ secrets.SONAR_TOKEN != '' }}` to the `sonarqube` job in `.github/workflows/sonarqube.yml` so the job only executes when the secret is present; all existing build and analysis steps (`./gradlew build`, `checkstyle`, `spotbugs`) are unchanged.

### Testing
- No automated test runs were triggered by this change; the update is a workflow gate that does not modify or execute the pipeline steps themselves.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a082fc784b48322ab1952cf17fb1194)