### PR TITLE
Bump dependency-review action and update several library versions in jhdf

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,4 +17,4 @@ jobs:
       - name: 'Checkout Repository'
         uses: actions/checkout@v6
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v5

--- a/jhdf/build.gradle
+++ b/jhdf/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     implementation 'org.slf4j:slf4j-api:2.0.17'
     implementation 'org.apache.commons:commons-lang3:3.20.0'
     // lzf compression support
-    implementation 'com.ning:compress-lzf:1.1.3'
+    implementation 'com.ning:compress-lzf:1.2.0'
     // lz4 support https://mvnrepository.com/artifact/at.yawk.lz4/lz4-java
     implementation 'at.yawk.lz4:lz4-java:1.11.0'
 
@@ -67,7 +67,7 @@ dependencies {
     testRuntimeOnly 'org.slf4j:slf4j-simple:2.0.17'
 
     // Mocking
-    testImplementation 'org.mockito:mockito-core:5.21.0'
+    testImplementation 'org.mockito:mockito-core:5.23.0'
     testImplementation 'org.powermock:powermock-core:2.0.9'
 
     // Matchers
@@ -77,8 +77,8 @@ dependencies {
     // Alternative bitshuffle impl to check results against
     testImplementation 'org.xerial.snappy:snappy-java:1.1.10.8'
     // For parsing h5dump XML output
-    testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.21.2'
-    testImplementation 'commons-io:commons-io:2.21.0'
+    testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.21.3'
+    testImplementation 'commons-io:commons-io:2.22.0'
     // For a FileSystemProvider implementation without FileChannel support
     testImplementation 'com.google.jimfs:jimfs:1.3.1'
 }

--- a/jhdf/gradle.lockfile
+++ b/jhdf/gradle.lockfile
@@ -1,12 +1,12 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-at.yawk.lz4:lz4-java:1.11.0=compileClasspath,jmhCompileClasspath,testCompileClasspath,testRuntimeClasspath
+at.yawk.lz4:lz4-java:1.11.0=compileClasspath,jmhCompileClasspath,jmhRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-annotations:2.21=jmhRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
-com.fasterxml.jackson.core:jackson-core:2.21.2=jmhRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
-com.fasterxml.jackson.core:jackson-databind:2.21.2=jmhRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.21.2=jmhRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
-com.fasterxml.jackson:jackson-bom:2.21.2=jmhRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.fasterxml.jackson.core:jackson-core:2.21.3=jmhRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.fasterxml.jackson.core:jackson-databind:2.21.3=jmhRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.21.3=jmhRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.fasterxml.jackson:jackson-bom:2.21.3=jmhRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.fasterxml.woodstox:woodstox-core:7.1.1=jmhRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.github.spotbugs:spotbugs-annotations:4.9.8=spotbugs
 com.github.spotbugs:spotbugs:4.9.8=spotbugs
@@ -20,13 +20,13 @@ com.google.guava:guava:33.4.8-jre=checkstyle,jmhRuntimeClasspath,testCompileClas
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava=checkstyle,jmhRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.google.j2objc:j2objc-annotations:3.0.0=checkstyle,jmhRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.google.jimfs:jimfs:1.3.1=jmhRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
-com.ning:compress-lzf:1.1.3=compileClasspath,jmhCompileClasspath,jmhRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.ning:compress-lzf:1.2.0=compileClasspath,jmhCompileClasspath,jmhRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.puppycrawl.tools:checkstyle:10.24.0=checkstyle
 commons-beanutils:commons-beanutils:1.10.1=checkstyle
 commons-codec:commons-codec:1.15=checkstyle
 commons-collections:commons-collections:3.2.2=checkstyle
 commons-io:commons-io:2.20.0=spotbugs
-commons-io:commons-io:2.21.0=jmhRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
+commons-io:commons-io:2.22.0=jmhRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
 info.picocli:picocli:4.7.7=checkstyle
 jaxen:jaxen:2.0.0=spotbugs
 net.bytebuddy:byte-buddy-agent:1.17.7=jmhRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
@@ -80,7 +80,7 @@ org.junit.platform:junit-platform-engine:1.13.4=jmhRuntimeClasspath,testRuntimeC
 org.junit.platform:junit-platform-launcher:1.13.4=jmhRuntimeClasspath,testRuntimeClasspath
 org.junit:junit-bom:5.13.4=jmhRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
 org.junit:junit-bom:5.14.0=spotbugs
-org.mockito:mockito-core:5.21.0=jmhRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.mockito:mockito-core:5.23.0=jmhRuntimeClasspath,testCompileClasspath,testRuntimeClasspath
 org.objenesis:objenesis:3.0.1=testCompileClasspath
 org.objenesis:objenesis:3.3=jmhRuntimeClasspath,testRuntimeClasspath
 org.openjdk.jmh:jmh-core:1.36=jmh,jmhCompileClasspath,jmhRuntimeClasspath


### PR DESCRIPTION
### Motivation

- Bring the repository tooling and libraries up to newer, compatible versions to address potential security fixes and dependency improvements.
- Ensure dependency scanning uses the newer `actions/dependency-review-action` release stream.

### Description

- Updated the GitHub workflow to use `actions/dependency-review-action@v5` in `.github/workflows/dependency-review.yml`.
- Bumped library versions in `jhdf/build.gradle` including `com.ning:compress-lzf` to `1.2.0`, `org.mockito:mockito-core` to `5.23.0`, `com.fasterxml.jackson.dataformat:jackson-dataformat-xml` to `2.21.3`, and `commons-io:commons-io` to `2.22.0`.
- Updated `jhdf/gradle.lockfile` to lock the corresponding upgraded versions and added an extra classpath entry for `at.yawk.lz4:lz4-java`.
- No functional or behavioral source code changes were made beyond dependency and lockfile updates.

### Testing

- Ran the test suite with `./gradlew test` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0830d825cc8322ad690261a46ae694)