### PR TITLE
fix: use bnd Gradle plugin to generate valid OSGi manifest

### DIFF
--- a/jhdf/bnd.bnd
+++ b/jhdf/bnd.bnd
@@ -1,0 +1,5 @@
+Bundle-SymbolicName: io.jhdf
+Bundle-Name: jhdf
+Bundle-Vendor: James Mudd
+Bundle-DocURL: https://jhdf.io/
+Export-Package: !io.jhdf.examples,!io.jhdf.examples.*,io.jhdf.*

--- a/jhdf/build.gradle
+++ b/jhdf/build.gradle
@@ -23,6 +23,7 @@ plugins {
     id 'org.sonarqube' version '7.3.0.8198' // Code quality
     id "com.github.spotbugs" version "6.5.5" // Static analysis
     id "me.champeau.jmh" version "0.7.3" // JMH support
+    id 'biz.aQute.bnd.builder' version '7.1.0' // OSGi manifest generation
 }
 
 // Variables
@@ -113,12 +114,7 @@ jar {
             'Automatic-Module-Name': 'io.jhdf',
             // OSGi headers
             'Bundle-ManifestVersion': '2',
-            'Bundle-SymbolicName': 'io.jhdf',
-            'Bundle-Name': project.name,
-            'Bundle-Vendor': 'James Mudd',
             'Bundle-Version': project.version,
-            'Export-Package': 'io.jhdf,io.jhdf.*,io.jhdf.api,io.jhdf.api.*',
-            'Require-Bundle': buildRequireBundleHeader(),
             // Build data
             'Build-JDK': System.getProperty('java.vendor') + ' ' + System.getProperty('java.version'),
             'Build-OS': System.getProperty('os.name') + ' ' + System.getProperty('os.version'),
@@ -214,8 +210,6 @@ signing {
 import com.github.spotbugs.snom.Confidence
 import com.github.spotbugs.snom.Effort
 
-import java.util.stream.Collectors
-
 spotbugs {
     ignoreFailures = true // Allow build to continue with errors
     effort = Effort.valueOf('MAX')
@@ -241,27 +235,4 @@ sonar {
     }
 }
 
-String buildRequireBundleHeader() {
-    def runtimeDependencies = configurations.runtimeClasspath.getAllDependencies()
-    def bundleToModule = [
-        "slf4j.api": "org.slf4j:slf4j-api",
-        "org.apache.commons.lang3": "org.apache.commons:commons-lang3",
-        "com.ning.compress-lzf": "com.ning:compress-lzf",
-        "lz4-java": "at.yawk.lz4:lz4-java"
-    ]
 
-    def moduleToVersion = runtimeDependencies.collectEntries {
-        [it.module.toString(), it.version]
-    }
-
-    //  Check here to catch when dependencies are added/removed
-    if(!bundleToModule.values().containsAll(moduleToVersion.keySet())) {
-        throw new IllegalStateException("Runtime dependencies not mapped for OSGi")
-    }
-
-    def header = bundleToModule.entrySet().stream()
-        .map {"${it.key};bundle-version=\"${moduleToVersion.get(it.value)}\"" }
-        .collect(Collectors.joining(","))
-
-    return header
-}


### PR DESCRIPTION
## Problem

The current manifest contains invalid OSGi headers:
- `Export-Package` uses wildcards (`io.jhdf.*`) which are **not valid in OSGi**
- `Require-Bundle` is used for dependency wiring, which is discouraged for libraries (should use `Import-Package` instead)

## Solution

Replace the manual manifest generation with the [bnd Gradle plugin](https://bnd.bndtools.org/chapters/150-build-plugins.html) (`biz.aQute.bnd.builder` v7.1.0), which:

- **Expands `Export-Package`** wildcards into fully-qualified package entries with proper `uses:` constraints and `version` attributes
- **Auto-generates `Import-Package`** from bytecode analysis, replacing the invalid `Require-Bundle`
- Adds `Require-Capability` for the Java EE requirement automatically

## Changes

- **`jhdf/bnd.bnd`** (new): OSGi instructions — `Export-Package` pattern excluding the examples package, plus static bundle metadata
- **`jhdf/build.gradle`**: Add `biz.aQute.bnd.builder` plugin, remove wildcard `Export-Package`, remove `Require-Bundle` and its `buildRequireBundleHeader()` helper

## Generated manifest (excerpt)

```
Export-Package: io.jhdf;uses:="io.jhdf.api,...";version="0.11.0",
 io.jhdf.api;uses:="...";version="0.11.0",
 io.jhdf.api.dataset;uses:="io.jhdf.api";version="0.11.0",
 ...
Import-Package: com.ning.compress.lzf;version="[1.2,2)",
 org.apache.commons.lang3;version="[3.20,4)",
 org.slf4j;version="[2.0,3)",
 ...
```

Fixes the OSGi manifest issue reported in the bug tracker.