### PR TITLE
Add writer API for unsigned FixedPoint datasets and attributes

### DIFF
--- a/jhdf/src/main/java/io/jhdf/AbstractWritableNode.java
+++ b/jhdf/src/main/java/io/jhdf/AbstractWritableNode.java
@@ -88,6 +88,16 @@ public abstract class AbstractWritableNode implements WritableNode {
 	}
 
 	@Override
+	public Attribute putAttribute(String name, Object data, boolean unsigned) {
+		if(StringUtils.isBlank(name)) {
+			throw new IllegalArgumentException("name cannot be null or blank");
+		}
+		Objects.requireNonNull(data, "Cannot write null attributes");
+		WritableAttributeImpl attribute = new WritableAttributeImpl(name, this, data, unsigned);
+		return attributes.put(name, attribute);
+	}
+
+	@Override
 	public Attribute removeAttribute(String name) {
 		return attributes.remove(name);
 	}

--- a/jhdf/src/main/java/io/jhdf/WritableDatasetImpl.java
+++ b/jhdf/src/main/java/io/jhdf/WritableDatasetImpl.java
@@ -73,44 +73,17 @@ public class WritableDatasetImpl extends AbstractWritableNode implements Writabl
 	private long storageInBytes = -1;
 
 	public WritableDatasetImpl(Object data, String name, Group parent) {
-		this(data, name, parent, DatasetCreationOptions.DEFAULT, false);
+		this(data, name, parent, DatasetCreationOptions.DEFAULT);
 	}
 
 	public WritableDatasetImpl(Object data, String name, Group parent, DatasetCreationOptions options) {
-		this(data, name, parent, options, false);
-	}
-
-	/**
-	 * Creates a writable dataset, optionally forcing the underlying fixed point (integer)
-	 * data type to be written as unsigned.
-	 *
-	 * @param data the dataset data, must be a supported fixed point (integer) array/scalar when {@code unsigned} is {@code true}
-	 * @param name the dataset name
-	 * @param parent the parent group
-	 * @param unsigned if {@code true} the data type will be written as unsigned fixed point
-	 */
-	public WritableDatasetImpl(Object data, String name, Group parent, boolean unsigned) {
-		this(data, name, parent, DatasetCreationOptions.DEFAULT, unsigned);
-	}
-
-	/**
-	 * Creates a writable dataset specifying how it is stored e.g. chunked and compressed, and
-	 * optionally forcing the underlying fixed point (integer) data type to be written as unsigned.
-	 *
-	 * @param data the dataset data, must be a supported fixed point (integer) array/scalar when {@code unsigned} is {@code true}
-	 * @param name the dataset name
-	 * @param parent the parent group
-	 * @param options Options controlling how the dataset is stored e.g. chunking and filters
-	 * @param unsigned if {@code true} the data type will be written as unsigned fixed point
-	 */
-	public WritableDatasetImpl(Object data, String name, Group parent, DatasetCreationOptions options, boolean unsigned) {
 		super(parent, name);
 		this.data = data;
-		this.dataType = DataType.fromObject(data, unsigned);
-		this.dataSpace = DataSpace.fromObject(data);
 		if (options == null) {
 			options = DatasetCreationOptions.DEFAULT;
 		}
+		this.dataType = DataType.fromObject(data, options.isUnsigned());
+		this.dataSpace = DataSpace.fromObject(data);
 		this.chunkDimensions = resolveChunkDimensions(options);
 		this.requestedFilters = chunkDimensions != null ? options.getFilters() : Collections.emptyList();
 	}

--- a/jhdf/src/main/java/io/jhdf/WritableDatasetImpl.java
+++ b/jhdf/src/main/java/io/jhdf/WritableDatasetImpl.java
@@ -73,13 +73,40 @@ public class WritableDatasetImpl extends AbstractWritableNode implements Writabl
 	private long storageInBytes = -1;
 
 	public WritableDatasetImpl(Object data, String name, Group parent) {
-		this(data, name, parent, DatasetCreationOptions.DEFAULT);
+		this(data, name, parent, DatasetCreationOptions.DEFAULT, false);
 	}
 
 	public WritableDatasetImpl(Object data, String name, Group parent, DatasetCreationOptions options) {
+		this(data, name, parent, options, false);
+	}
+
+	/**
+	 * Creates a writable dataset, optionally forcing the underlying fixed point (integer)
+	 * data type to be written as unsigned.
+	 *
+	 * @param data the dataset data, must be a supported fixed point (integer) array/scalar when {@code unsigned} is {@code true}
+	 * @param name the dataset name
+	 * @param parent the parent group
+	 * @param unsigned if {@code true} the data type will be written as unsigned fixed point
+	 */
+	public WritableDatasetImpl(Object data, String name, Group parent, boolean unsigned) {
+		this(data, name, parent, DatasetCreationOptions.DEFAULT, unsigned);
+	}
+
+	/**
+	 * Creates a writable dataset specifying how it is stored e.g. chunked and compressed, and
+	 * optionally forcing the underlying fixed point (integer) data type to be written as unsigned.
+	 *
+	 * @param data the dataset data, must be a supported fixed point (integer) array/scalar when {@code unsigned} is {@code true}
+	 * @param name the dataset name
+	 * @param parent the parent group
+	 * @param options Options controlling how the dataset is stored e.g. chunking and filters
+	 * @param unsigned if {@code true} the data type will be written as unsigned fixed point
+	 */
+	public WritableDatasetImpl(Object data, String name, Group parent, DatasetCreationOptions options, boolean unsigned) {
 		super(parent, name);
 		this.data = data;
-		this.dataType = DataType.fromObject(data);
+		this.dataType = DataType.fromObject(data, unsigned);
 		this.dataSpace = DataSpace.fromObject(data);
 		if (options == null) {
 			options = DatasetCreationOptions.DEFAULT;

--- a/jhdf/src/main/java/io/jhdf/WritableGroupImpl.java
+++ b/jhdf/src/main/java/io/jhdf/WritableGroupImpl.java
@@ -140,24 +140,6 @@ public class WritableGroupImpl extends AbstractWritableNode implements WritableG
     return writableDataset;
   }
 
-  @Override
-  public WritableDataset putDataset(String name, Object data, boolean unsigned) {
-    if (StringUtils.isBlank(name)) {
-      throw new IllegalArgumentException("name cannot be null or blank");
-    }
-    if (data instanceof WritableDataset) {
-      throw new IllegalArgumentException(
-          "unsigned cannot be applied to a pre-initialized WritableDataset");
-    }
-    logger.debug(
-        "putting inferred dataset with type and shape inference '" + name + "' into " + "group '"
-        + this.getName() + "'");
-    WritableDataset writableDataset = new WritableDatasetImpl(data, name, this, unsigned);
-    children.put(name, writableDataset);
-    logger.info("Added dataset [{}] to group [{}]", name, getPath());
-    return writableDataset;
-  }
-
 	@Override
 	public WritableGroup putGroup(String name) {
 		if(StringUtils.isBlank(name)) {

--- a/jhdf/src/main/java/io/jhdf/WritableGroupImpl.java
+++ b/jhdf/src/main/java/io/jhdf/WritableGroupImpl.java
@@ -140,6 +140,23 @@ public class WritableGroupImpl extends AbstractWritableNode implements WritableG
     return writableDataset;
   }
 
+  @Override
+  public WritableDataset putDataset(String name, Object data, boolean unsigned) {
+    if (StringUtils.isBlank(name)) {
+      throw new IllegalArgumentException("name cannot be null or blank");
+    }
+    if (data instanceof WritableDataset) {
+      throw new IllegalArgumentException(
+          "unsigned cannot be applied to a pre-initialized WritableDataset");
+    }
+    logger.debug(
+        "putting inferred dataset with type and shape inference '" + name + "' into " + "group '"
+        + this.getName() + "'");
+    WritableDataset writableDataset = new WritableDatasetImpl(data, name, this, unsigned);
+    children.put(name, writableDataset);
+    logger.info("Added dataset [{}] to group [{}]", name, getPath());
+    return writableDataset;
+  }
 
 	@Override
 	public WritableGroup putGroup(String name) {

--- a/jhdf/src/main/java/io/jhdf/WritableHdfFile.java
+++ b/jhdf/src/main/java/io/jhdf/WritableHdfFile.java
@@ -118,14 +118,6 @@ public class WritableHdfFile implements WritableGroup, AutoCloseable {
 	 {@inheritDoc}
 	 */
 	@Override
-	public WritableDataset putDataset(String name, Object data, boolean unsigned) {
-		return rootGroup.putDataset(name, data, unsigned);
-	}
-
-	/**
-	 {@inheritDoc}
-	 */
-	@Override
 	public WritableGroup putGroup(String name) {
 		return rootGroup.putGroup(name);
 	}

--- a/jhdf/src/main/java/io/jhdf/WritableHdfFile.java
+++ b/jhdf/src/main/java/io/jhdf/WritableHdfFile.java
@@ -118,6 +118,14 @@ public class WritableHdfFile implements WritableGroup, AutoCloseable {
 	 {@inheritDoc}
 	 */
 	@Override
+	public WritableDataset putDataset(String name, Object data, boolean unsigned) {
+		return rootGroup.putDataset(name, data, unsigned);
+	}
+
+	/**
+	 {@inheritDoc}
+	 */
+	@Override
 	public WritableGroup putGroup(String name) {
 		return rootGroup.putGroup(name);
 	}
@@ -208,6 +216,14 @@ public class WritableHdfFile implements WritableGroup, AutoCloseable {
 	@Override
 	public Attribute putAttribute(String name, Object data) {
 		return rootGroup.putAttribute(name, data);
+	}
+
+	/**
+	 {@inheritDoc}
+	 */
+	@Override
+	public Attribute putAttribute(String name, Object data, boolean unsigned) {
+		return rootGroup.putAttribute(name, data, unsigned);
 	}
 
 	/**

--- a/jhdf/src/main/java/io/jhdf/api/DatasetCreationOptions.java
+++ b/jhdf/src/main/java/io/jhdf/api/DatasetCreationOptions.java
@@ -45,10 +45,12 @@ public final class DatasetCreationOptions {
 
 	private final int[] chunkDimensions;
 	private final List<RequestedFilter> filters;
+	private final boolean unsigned;
 
 	private DatasetCreationOptions(Builder builder) {
 		this.chunkDimensions = ArrayUtils.clone(builder.chunkDimensions);
 		this.filters = Collections.unmodifiableList(new ArrayList<>(builder.filters));
+		this.unsigned = builder.unsigned;
 	}
 
 	public static Builder builder() {
@@ -60,6 +62,13 @@ public final class DatasetCreationOptions {
 	 */
 	public boolean isChunked() {
 		return chunkDimensions != null || !filters.isEmpty();
+	}
+
+	/**
+	 * @return true if the underlying fixed point (integer) data type should be written as unsigned
+	 */
+	public boolean isUnsigned() {
+		return unsigned;
 	}
 
 	/**
@@ -101,8 +110,21 @@ public final class DatasetCreationOptions {
 
 		private int[] chunkDimensions;
 		private final List<RequestedFilter> filters = new ArrayList<>();
+		private boolean unsigned;
 
 		private Builder() {
+		}
+
+		/**
+		 * Forces the underlying fixed point (integer) data type to be written as unsigned. This only applies when
+		 * the dataset data is a supported fixed point (integer) array/scalar (byte/short/int/long); requesting
+		 * unsigned for any other data type will result in an exception.
+		 *
+		 * @return this builder
+		 */
+		public Builder unsigned() {
+			this.unsigned = true;
+			return this;
 		}
 
 		/**

--- a/jhdf/src/main/java/io/jhdf/api/WritableAttributeImpl.java
+++ b/jhdf/src/main/java/io/jhdf/api/WritableAttributeImpl.java
@@ -25,10 +25,23 @@ public class WritableAttributeImpl implements Attribute {
 	private final DataSpace dataSpace;
 
 	public WritableAttributeImpl(String name, Node node, Object data) {
+		this(name, node, data, false);
+	}
+
+	/**
+	 * Creates a writable attribute, optionally forcing the underlying fixed point (integer)
+	 * data type to be written as unsigned.
+	 *
+	 * @param name the attribute name
+	 * @param node the node this attribute belongs to
+	 * @param data the attribute data, must be a supported fixed point (integer) array/scalar when {@code unsigned} is {@code true}
+	 * @param unsigned if {@code true} the data type will be written as unsigned fixed point
+	 */
+	public WritableAttributeImpl(String name, Node node, Object data, boolean unsigned) {
 		this.name = name;
 		this.node = node;
 		this.data = data;
-		this.dataType = DataType.fromObject(data);
+		this.dataType = DataType.fromObject(data, unsigned);
 		this.dataSpace = DataSpace.fromObject(data);
 	}
 	@Override

--- a/jhdf/src/main/java/io/jhdf/api/WritableGroup.java
+++ b/jhdf/src/main/java/io/jhdf/api/WritableGroup.java
@@ -25,29 +25,16 @@ public interface WritableGroup extends Group, WritableNode {
 	WritableDataset putDataset(String name, Object data);
 
 	/**
-	 Put a named dataset into the group specifying how it is stored e.g. chunked and compressed. See
-	 {@link DatasetCreationOptions}.
+	 Put a named dataset into the group specifying how it is stored e.g. chunked and compressed, and/or forcing the
+	 underlying fixed point (integer) data type to be written as unsigned. See {@link DatasetCreationOptions}.
 
 	 * @param name The dataset name within this group
 	 * @param data The dataset array
-	 * @param options Options controlling how the dataset is stored e.g. chunking and filters
+	 * @param options Options controlling how the dataset is stored e.g. chunking, filters and unsigned fixed point types
 	 * @return the dataset, for further modification
 	 * @since v0.13.0
 	 */
 	WritableDataset putDataset(String name, Object data, DatasetCreationOptions options);
-
-	/**
-	 Put a named dataset into the group, optionally forcing the underlying fixed point
-	 (integer) data type to be written as unsigned. This only applies when {@code data} is a
-	 supported fixed point (integer) array/scalar (byte/short/int/long); requesting
-	 {@code unsigned} for any other data type will result in an exception.
-
-	 * @param name The dataset name within this group
-	 * @param data The dataset array or scalar, must be a fixed point (integer) type when {@code unsigned} is {@code true}
-	 * @param unsigned if {@code true} the dataset will be written as an unsigned fixed point type
-	 * @return the dataset, for further modification
-	 */
-	WritableDataset putDataset(String name, Object data, boolean unsigned);
 
 	WritableGroup putGroup(String name);
 

--- a/jhdf/src/main/java/io/jhdf/api/WritableGroup.java
+++ b/jhdf/src/main/java/io/jhdf/api/WritableGroup.java
@@ -36,6 +36,19 @@ public interface WritableGroup extends Group, WritableNode {
 	 */
 	WritableDataset putDataset(String name, Object data, DatasetCreationOptions options);
 
+	/**
+	 Put a named dataset into the group, optionally forcing the underlying fixed point
+	 (integer) data type to be written as unsigned. This only applies when {@code data} is a
+	 supported fixed point (integer) array/scalar (byte/short/int/long); requesting
+	 {@code unsigned} for any other data type will result in an exception.
+
+	 * @param name The dataset name within this group
+	 * @param data The dataset array or scalar, must be a fixed point (integer) type when {@code unsigned} is {@code true}
+	 * @param unsigned if {@code true} the dataset will be written as an unsigned fixed point type
+	 * @return the dataset, for further modification
+	 */
+	WritableDataset putDataset(String name, Object data, boolean unsigned);
+
 	WritableGroup putGroup(String name);
 
 }

--- a/jhdf/src/main/java/io/jhdf/api/WritableNode.java
+++ b/jhdf/src/main/java/io/jhdf/api/WritableNode.java
@@ -34,6 +34,19 @@ public interface WritableNode extends Node {
 	Attribute putAttribute(String name, Object data);
 
 	/**
+	 * Adds an attribute to this node, optionally forcing the underlying fixed point
+	 * (integer) data type to be written as unsigned. This only applies when {@code data} is
+	 * a supported fixed point (integer) array/scalar (byte/short/int/long); requesting
+	 * {@code unsigned} for any other data type will result in an exception.
+	 *
+	 * @param name The attributes name
+	 * @param data The attributes data, must be a fixed point (integer) type when {@code unsigned} is {@code true}
+	 * @param unsigned if {@code true} the attribute will be written as an unsigned fixed point type
+	 * @return The attribute
+	 */
+	Attribute putAttribute(String name, Object data, boolean unsigned);
+
+	/**
 	 * Removes an attribute from this node
 	 *
 	 * @since v0.8.0

--- a/jhdf/src/main/java/io/jhdf/object/datatype/DataType.java
+++ b/jhdf/src/main/java/io/jhdf/object/datatype/DataType.java
@@ -123,6 +123,36 @@ public abstract class DataType {
 		}
 	}
 
+	/**
+	 * Creates a {@link DataType} for the supplied data, optionally forcing it to be written
+	 * as an unsigned fixed point type. This is only applicable to integer (fixed point) data,
+	 * i.e. byte/short/int/long arrays. Requesting an unsigned type for any other data type
+	 * will result in an exception.
+	 *
+	 * @param data the data to create a {@link DataType} for
+	 * @param unsigned if {@code true} the returned {@link DataType} will be an unsigned fixed point type
+	 * @return the created {@link DataType}
+	 */
+	public static DataType fromObject(Object data, boolean unsigned) {
+		if (!unsigned) {
+			return fromObject(data);
+		}
+
+		final Class<?> type = Utils.getType(data);
+
+		if (type == byte.class || type == Byte.class) {
+			return new FixedPoint(1, false);
+		} else if (type == short.class || type == Short.class) {
+			return new FixedPoint(2, false);
+		} else if (type == int.class || type == Integer.class) {
+			return new FixedPoint(4, false);
+		} else if (type == long.class || type == Long.class) {
+			return new FixedPoint(8, false);
+		} else {
+			throw new HdfException("Unsigned data type is only supported for fixed point (integer) data, got: " + type);
+		}
+	}
+
 	public int getVersion() {
 		return version;
 	}

--- a/jhdf/src/main/java/io/jhdf/object/datatype/FixedPoint.java
+++ b/jhdf/src/main/java/io/jhdf/object/datatype/FixedPoint.java
@@ -60,13 +60,17 @@ public class FixedPoint extends DataType implements OrderedDataType, WritableDat
 	}
 
 	public FixedPoint(int bytePrecision) {
+		this(bytePrecision, true);
+	}
+
+	public FixedPoint(int bytePrecision, boolean signed) {
 		// TODO arg validation
 		super(CLASS_ID, bytePrecision);
 		this.order = ByteOrder.nativeOrder();
 		this.bitPrecision = (short) (bytePrecision * 8);
 		this.lowPadding = false;
 		this.highPadding = false;
-		this.signed = true;
+		this.signed = signed;
 		this.bitOffset = 0; // TODO ok?
 	}
 

--- a/jhdf/src/test/java/io/jhdf/writing/UnsignedWritingTest.java
+++ b/jhdf/src/test/java/io/jhdf/writing/UnsignedWritingTest.java
@@ -1,0 +1,64 @@
+/*
+ * This file is part of jHDF. A pure Java library for accessing HDF5 files.
+ *
+ * https://jhdf.io
+ *
+ * Copyright (c) 2025 James Mudd
+ *
+ * MIT License see 'LICENSE' file
+ */
+
+package io.jhdf.writing;
+
+import io.jhdf.HdfFile;
+import io.jhdf.WritableHdfFile;
+import io.jhdf.api.Attribute;
+import io.jhdf.api.Dataset;
+import io.jhdf.exceptions.HdfException;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class UnsignedWritingTest {
+
+	@Test
+	void writeUnsignedDatasetAndAttribute() throws Exception {
+		Path tempFile = Files.createTempFile(this.getClass().getSimpleName(), ".hdf5");
+		WritableHdfFile writableHdfFile = HdfFile.write(tempFile);
+
+		writableHdfFile.putDataset("UnsignedShortDataset", new short[]{-1, 0, 1, 133}, true);
+		writableHdfFile.putAttribute("UnsignedByteAttribute", (byte) -1, true);
+
+		writableHdfFile.close();
+
+		try (HdfFile hdfFile = new HdfFile(tempFile)) {
+			Dataset dataset = hdfFile.getDatasetByPath("UnsignedShortDataset");
+			// unsigned shorts get promoted to int in jHDF
+			assertThat(dataset.getJavaType()).isEqualTo(int.class);
+			int[] data = (int[]) dataset.getData();
+			assertThat(data).containsExactly(65535, 0, 1, 133);
+
+			Attribute attribute = hdfFile.getAttribute("UnsignedByteAttribute");
+			assertThat(attribute.getJavaType()).isEqualTo(Integer.class);
+			assertThat(attribute.getData()).isEqualTo(255);
+		}
+	}
+
+	@Test
+	void unsignedNotSupportedForNonFixedPointTypes() throws Exception {
+		Path tempFile = Files.createTempFile(this.getClass().getSimpleName(), ".hdf5");
+		WritableHdfFile writableHdfFile = HdfFile.write(tempFile);
+
+		assertThatThrownBy(() -> writableHdfFile.putDataset("bad", 1.23, true))
+			.isInstanceOf(HdfException.class);
+
+		assertThatThrownBy(() -> writableHdfFile.putAttribute("bad", "notFixedPoint", true))
+			.isInstanceOf(HdfException.class);
+
+		writableHdfFile.close();
+	}
+}

--- a/jhdf/src/test/java/io/jhdf/writing/UnsignedWritingTest.java
+++ b/jhdf/src/test/java/io/jhdf/writing/UnsignedWritingTest.java
@@ -14,6 +14,7 @@ import io.jhdf.HdfFile;
 import io.jhdf.WritableHdfFile;
 import io.jhdf.api.Attribute;
 import io.jhdf.api.Dataset;
+import io.jhdf.api.DatasetCreationOptions;
 import io.jhdf.exceptions.HdfException;
 import org.junit.jupiter.api.Test;
 
@@ -30,7 +31,8 @@ class UnsignedWritingTest {
 		Path tempFile = Files.createTempFile(this.getClass().getSimpleName(), ".hdf5");
 		WritableHdfFile writableHdfFile = HdfFile.write(tempFile);
 
-		writableHdfFile.putDataset("UnsignedShortDataset", new short[]{-1, 0, 1, 133}, true);
+		writableHdfFile.putDataset("UnsignedShortDataset", new short[]{-1, 0, 1, 133},
+			DatasetCreationOptions.builder().unsigned().build());
 		writableHdfFile.putAttribute("UnsignedByteAttribute", (byte) -1, true);
 
 		writableHdfFile.close();
@@ -53,7 +55,8 @@ class UnsignedWritingTest {
 		Path tempFile = Files.createTempFile(this.getClass().getSimpleName(), ".hdf5");
 		WritableHdfFile writableHdfFile = HdfFile.write(tempFile);
 
-		assertThatThrownBy(() -> writableHdfFile.putDataset("bad", 1.23, true))
+		assertThatThrownBy(() -> writableHdfFile.putDataset("bad", 1.23,
+			DatasetCreationOptions.builder().unsigned().build()))
 			.isInstanceOf(HdfException.class);
 
 		assertThatThrownBy(() -> writableHdfFile.putAttribute("bad", "notFixedPoint", true))


### PR DESCRIPTION
Currently jHDF can *read* unsigned data but you can not *write* unsigned data as there is no API and the signed flag is always true.

This now adds a new API and test to allow passing an optional `unsigned` flag to be written with the data.