### PR TITLE
Combine decompression and conversion for parallel chunked dataset reads

### DIFF
--- a/jhdf/src/main/java/io/jhdf/dataset/chunked/ChunkedDatasetBase.java
+++ b/jhdf/src/main/java/io/jhdf/dataset/chunked/ChunkedDatasetBase.java
@@ -18,13 +18,16 @@ import io.jhdf.exceptions.HdfException;
 import io.jhdf.filter.FilterManager;
 import io.jhdf.filter.FilterPipeline;
 import io.jhdf.filter.PipelineFilterWithData;
+import io.jhdf.object.datatype.DataType;
 import io.jhdf.object.message.FilterPipelineMessage;
 import io.jhdf.storage.HdfBackingStorage;
 import org.apache.commons.lang3.concurrent.ConcurrentException;
 import org.apache.commons.lang3.concurrent.LazyInitializer;
+import org.apache.commons.lang3.time.StopWatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.Array;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -33,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 
 import static java.lang.Math.toIntExact;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public abstract class ChunkedDatasetBase extends DatasetBase implements ChunkedDataset {
 	private static final Logger logger = LoggerFactory.getLogger(ChunkedDatasetBase.class);
@@ -465,5 +469,183 @@ public abstract class ChunkedDatasetBase extends DatasetBase implements ChunkedD
 		} catch (ConcurrentException e) {
 			throw new HdfException("Failed to create filter pipeline", e);
 		}
+	}
+
+	@Override
+	public Object getData() {
+		if (!useDirectFillPath()) {
+			return super.getData();
+		}
+
+		logger.info("Getting data for '{}'...", getPath());
+
+		final int[] dims;
+		try {
+			dims = getDimensions();
+		} catch (ArithmeticException e) {
+			throw new HdfException("Dataset '" + getPath() + "' has dimensions that exceed Integer.MAX_VALUE. Use getData(sliceOffset, sliceDimensions) to read slices instead.", e);
+		}
+
+		final StopWatch stopWatch = StopWatch.createStarted();
+
+		// Create the correctly typed and sized output array up front, then read, decompress,
+		// convert and fill each chunk into it in parallel
+		final Object data = Array.newInstance(getDataType().getJavaType(), dims);
+		fillDataInParallel(data, dims);
+
+		stopWatch.stop();
+		logger.info("Finished getting data for [{}] took [{}ms]", getPath(), stopWatch.getTime(MILLISECONDS));
+		return data;
+	}
+
+	@Override
+	public Object getDataFlat() {
+		if (!useDirectFillPath()) {
+			return super.getDataFlat();
+		}
+
+		logger.info("Getting flat data for '{}'...", getPath());
+
+		final int elements;
+		try {
+			elements = Math.toIntExact(getSize());
+		} catch (ArithmeticException e) {
+			throw new HdfException("Dataset '" + getPath() + "' has more than Integer.MAX_VALUE elements. Use getData(sliceOffset, sliceDimensions) to read slices instead.", e);
+		}
+
+		final StopWatch stopWatch = StopWatch.createStarted();
+
+		// As getData but into a flat 1-D array
+		final Object data = Array.newInstance(getDataType().getJavaType(), elements);
+		fillDataInParallel(data, new int[]{elements});
+
+		stopWatch.stop();
+		logger.info("Finished getting flat data for [{}] took [{}ms]", getPath(), stopWatch.getTime(MILLISECONDS));
+		return data;
+	}
+
+	/**
+	 * The direct fill path can be used when the dataset is not empty or scalar and the data type
+	 * supports converting elements straight from the decompressed chunk buffer into the output
+	 * array. Otherwise the fallback path via an intermediate {@link ByteBuffer} is used.
+	 *
+	 * @return true if this dataset can be read using the direct fill path
+	 */
+	private boolean useDirectFillPath() {
+		return !isEmpty() && !isScalar() && getDataType().supportsDirectFill();
+	}
+
+	/**
+	 * Reads, decompresses, converts and fills each chunk into the final typed output array in
+	 * parallel. Multiple threads write to disjoint regions of the output array concurrently.
+	 *
+	 * @param data    the typed output array to fill
+	 * @param navDims the dimensions used to navigate {@code data} (the dataset dimensions, or a
+	 *                single total elements dimension for flat reads)
+	 */
+	private void fillDataInParallel(final Object data, final int[] navDims) {
+		final int elementSize = getDataType().getSize();
+
+		// Get all chunks because we're reading the whole dataset
+		final Collection<Chunk> chunks = getAllChunks();
+
+		// These are all the same for every chunk
+		final int[] chunkDimensions = getChunkDimensions();
+		final int[] chunkInternalOffsets = getChunkInternalOffsets(chunkDimensions, elementSize);
+		final int[] dataOffsets = getDataOffsets(chunkInternalOffsets);
+		final int fastestChunkDim = chunkDimensions[chunkDimensions.length - 1];
+
+		// Parallel reading, decompression, conversion and filling, this is where all the work is done
+		chunks.parallelStream().forEach(chunk -> fillTypedDataFromChunk(chunk, data, navDims, chunkDimensions, chunkInternalOffsets, dataOffsets, fastestChunkDim, elementSize));
+	}
+
+	/**
+	 * Reads and decompresses a single chunk then converts its rows into the dataset data type
+	 * writing them directly into the correct locations of the output array.
+	 */
+	private void fillTypedDataFromChunk(final Chunk chunk, final Object data, final int[] navDims, final int[] chunkDimensions, final int[] chunkInternalOffsets, final int[] dataOffsets, final int fastestChunkDim, final int elementSize) {
+
+		logger.trace("Filling typed data from chunk '{}'", chunk);
+
+		final int[] datasetDimensions = getDimensions();
+		final DataType dataType = getDataType();
+
+		// Read and un-filter (decompress) the data in this chunk
+		final byte[] chunkData = decompressChunk(chunk);
+		final ByteBuffer chunkBuffer = ByteBuffer.wrap(chunkData);
+
+		// Now need to figure out how to put this chunks data into the output array
+		final int[] chunkOffset = toIntArray(chunk.getChunkOffset());
+		final int initialChunkOffset = Utils.dimensionIndexToLinearIndex(chunkOffset, datasetDimensions);
+
+		if (!isPartialChunk(chunk)) {
+			// Not a partial chunk so can always copy the max amount
+			for (int i = 0; i < chunkInternalOffsets.length; i++) {
+				fillRow(data, navDims, dataOffsets[i] + initialChunkOffset, // dest
+						dataType, chunkBuffer, chunkInternalOffsets[i] / elementSize, // src
+						fastestChunkDim); // length
+			}
+		} else {
+			logger.trace("Handling partial chunk '{}'", chunk);
+			// Partial chunk
+			final int highestDimIndex = datasetDimensions.length - 1;
+			final int totalBytes = toIntExact(getSizeInBytes());
+
+			for (int i = 0; i < chunkInternalOffsets.length; i++) {
+				// Quick check first if the data starts outside then we know this part of the chunk can be skipped
+				// Does not consider dimensions
+				if (dataOffsets[i] > totalBytes) {
+					continue;
+				}
+				// Is this part of the chunk outside the dataset including dimensions?
+				if (partOfChunkIsOutsideDataset(chunkInternalOffsets[i] / elementSize, chunkDimensions, chunkOffset)) {
+					continue;
+				}
+
+				// Its inside so we need to copy at least something. Now work out how much?
+				final int length = Math.min(fastestChunkDim, fastestChunkDim - (chunkOffset[highestDimIndex] + chunkDimensions[highestDimIndex] - datasetDimensions[highestDimIndex]));
+
+				fillRow(data, navDims, dataOffsets[i] + initialChunkOffset, // dest
+						dataType, chunkBuffer, chunkInternalOffsets[i] / elementSize, // src
+						length); // length
+			}
+		}
+	}
+
+	/**
+	 * Converts one contiguous run of elements from the decompressed chunk buffer into the dataset
+	 * data type and writes it into the correct innermost row of the output array.
+	 *
+	 * @param data              the typed output array being filled
+	 * @param navDims           the dimensions used to navigate {@code data}
+	 * @param destElementOffset the linear element offset in the dataset this run starts at
+	 * @param dataType          the data type used to convert the raw bytes
+	 * @param chunkBuffer       the decompressed chunk data
+	 * @param srcElementOffset  the element offset inside the chunk this run starts at
+	 * @param length            the number of elements in this run
+	 */
+	private static void fillRow(final Object data, final int[] navDims, final int destElementOffset, final DataType dataType, final ByteBuffer chunkBuffer, final int srcElementOffset, final int length) {
+		final int rowLength = navDims[navDims.length - 1];
+
+		final Object rowArray;
+		final int rowOffset;
+		if (navDims.length > 1) {
+			// Runs never cross rows so this run lies entirely within one innermost row array
+			final int rowIndex = destElementOffset / rowLength;
+			rowOffset = destElementOffset % rowLength;
+			// Navigate to the innermost row array containing this run
+			final int[] leadingDims = Arrays.copyOf(navDims, navDims.length - 1);
+			Object array = data;
+			for (final int index : Utils.linearIndexToDimensionIndex(rowIndex, leadingDims)) {
+				array = Array.get(array, index);
+			}
+			rowArray = array;
+		} else {
+			// 1-D (or flat) output, the whole array is the row
+			rowArray = data;
+			rowOffset = destElementOffset;
+		}
+
+		dataType.fillElements(rowArray, rowOffset, chunkBuffer, srcElementOffset, length);
 	}
 }

--- a/jhdf/src/main/java/io/jhdf/object/datatype/DataType.java
+++ b/jhdf/src/main/java/io/jhdf/object/datatype/DataType.java
@@ -157,6 +157,35 @@ public abstract class DataType {
 	 */
 	public abstract Object fillData(ByteBuffer buffer, int[] dimensions, HdfBackingStorage hdfBackingStorage);
 
+	/**
+	 * Whether this {@link DataType} supports filling elements directly from a decompressed chunk
+	 * buffer into an already allocated output array. Types supporting it can be read using the
+	 * combined parallel read path in chunked datasets, where each chunk is read, decompressed,
+	 * converted and written into the final typed array in a single parallel step. Types returning
+	 * {@code false} fall back to reading into an intermediate {@link ByteBuffer} and converting
+	 * afterwards.
+	 *
+	 * @return true if this type supports direct filling
+	 */
+	public boolean supportsDirectFill() {
+		return false;
+	}
+
+	/**
+	 * Fills {@code length} elements from the decompressed chunk buffer into an innermost (1-D)
+	 * row of the output array. Implementations convert the raw bytes into the correct Java type
+	 * as part of the copy, so no intermediate full-dataset buffer is needed.
+	 *
+	 * @param rowArray            the innermost array of the output to fill (e.g. {@code int[]})
+	 * @param rowOffset           element offset within {@code rowArray} to start writing at
+	 * @param buffer              the decompressed chunk data
+	 * @param bufferElementOffset element offset within the chunk buffer to start reading from
+	 * @param length              number of elements to copy
+	 */
+	public void fillElements(Object rowArray, int rowOffset, ByteBuffer buffer, int bufferElementOffset, int length) {
+		throw new UnsupportedHdfException("Data type [" + getClass().getSimpleName() + "] does not support direct filling");
+	}
+
 	// TODO could be abstract when there are more impls
 	public ByteBuffer encodeData(Object data){
 		throw new UnsupportedHdfException("Data type [" + getClass().getSimpleName() + "] does not support writing");

--- a/jhdf/src/main/java/io/jhdf/object/datatype/FixedPoint.java
+++ b/jhdf/src/main/java/io/jhdf/object/datatype/FixedPoint.java
@@ -169,6 +169,87 @@ public class FixedPoint extends DataType implements OrderedDataType, WritableDat
 		return data;
 	}
 
+	@Override
+	public boolean supportsDirectFill() {
+		return true;
+	}
+
+	@Override
+	public void fillElements(Object rowArray, int rowOffset, ByteBuffer buffer, int bufferElementOffset, int length) {
+		final ByteOrder byteOrder = getByteOrder();
+		if (isSigned()) {
+			switch (getSize()) {
+				case 1:
+					buffer.duplicate().order(byteOrder)
+							.get(bufferElementOffset, (byte[]) rowArray, rowOffset, length);
+					break;
+				case 2:
+					buffer.duplicate().order(byteOrder).asShortBuffer()
+							.get(bufferElementOffset, (short[]) rowArray, rowOffset, length);
+					break;
+				case 4:
+					buffer.duplicate().order(byteOrder).asIntBuffer()
+							.get(bufferElementOffset, (int[]) rowArray, rowOffset, length);
+					break;
+				case 8:
+					buffer.duplicate().order(byteOrder).asLongBuffer()
+							.get(bufferElementOffset, (long[]) rowArray, rowOffset, length);
+					break;
+				default:
+					throw new HdfTypeException(
+						"Unsupported signed integer type size " + getSize() + " bytes");
+			}
+		} else { // Unsigned needs promotion to the next larger Java type
+			switch (getSize()) {
+				case 1:
+					fillUnsignedBytes(rowArray, rowOffset, buffer.duplicate().order(byteOrder), bufferElementOffset, length);
+					break;
+				case 2:
+					fillUnsignedShorts(rowArray, rowOffset, buffer.duplicate().order(byteOrder).asShortBuffer(), bufferElementOffset, length);
+					break;
+				case 4:
+					fillUnsignedInts(rowArray, rowOffset, buffer.duplicate().order(byteOrder).asIntBuffer(), bufferElementOffset, length);
+					break;
+				case 8:
+					fillUnsignedLongs(rowArray, rowOffset, buffer.duplicate().order(byteOrder).asLongBuffer(), bufferElementOffset, length);
+					break;
+				default:
+					throw new HdfTypeException(
+						"Unsupported unsigned integer type size " + getSize() + " bytes");
+			}
+		}
+	}
+
+	private static void fillUnsignedBytes(Object rowArray, int rowOffset, ByteBuffer buffer, int bufferElementOffset, int length) {
+		final int[] intData = (int[]) rowArray;
+		for (int i = 0; i < length; i++) {
+			intData[rowOffset + i] = Byte.toUnsignedInt(buffer.get(bufferElementOffset + i));
+		}
+	}
+
+	private static void fillUnsignedShorts(Object rowArray, int rowOffset, ShortBuffer buffer, int bufferElementOffset, int length) {
+		final int[] intData = (int[]) rowArray;
+		for (int i = 0; i < length; i++) {
+			intData[rowOffset + i] = Short.toUnsignedInt(buffer.get(bufferElementOffset + i));
+		}
+	}
+
+	private static void fillUnsignedInts(Object rowArray, int rowOffset, IntBuffer buffer, int bufferElementOffset, int length) {
+		final long[] longData = (long[]) rowArray;
+		for (int i = 0; i < length; i++) {
+			longData[rowOffset + i] = Integer.toUnsignedLong(buffer.get(bufferElementOffset + i));
+		}
+	}
+
+	private static void fillUnsignedLongs(Object rowArray, int rowOffset, LongBuffer buffer, int bufferElementOffset, int length) {
+		final ByteBuffer tempByteBuffer = ByteBuffer.allocate(8);
+		final BigInteger[] bigIntData = (BigInteger[]) rowArray;
+		for (int i = 0; i < length; i++) {
+			tempByteBuffer.putLong(0, buffer.get(bufferElementOffset + i));
+			bigIntData[rowOffset + i] = new BigInteger(1, tempByteBuffer.array());
+		}
+	}
+
     @Override
     public ByteBuffer encodeData(Object data) {
 		Objects.requireNonNull(data, "Cannot encode null");

--- a/jhdf/src/main/java/io/jhdf/object/datatype/FloatingPoint.java
+++ b/jhdf/src/main/java/io/jhdf/object/datatype/FloatingPoint.java
@@ -200,6 +200,39 @@ public class FloatingPoint extends DataType implements OrderedDataType {
 		return data;
 	}
 
+	@Override
+	public boolean supportsDirectFill() {
+		return true;
+	}
+
+	@Override
+	public void fillElements(Object rowArray, int rowOffset, ByteBuffer buffer, int bufferElementOffset, int length) {
+		final ByteOrder byteOrder = getByteOrder();
+		switch (getSize()) {
+			case 2:
+				fillHalfFloats(rowArray, rowOffset, buffer.duplicate().order(byteOrder).asShortBuffer(), bufferElementOffset, length);
+				break;
+			case 4:
+				buffer.duplicate().order(byteOrder).asFloatBuffer()
+						.get(bufferElementOffset, (float[]) rowArray, rowOffset, length);
+				break;
+			case 8:
+				buffer.duplicate().order(byteOrder).asDoubleBuffer()
+						.get(bufferElementOffset, (double[]) rowArray, rowOffset, length);
+				break;
+			default:
+				throw new HdfTypeException(
+					"Unsupported floating point type size " + getSize() + " bytes");
+		}
+	}
+
+	private static void fillHalfFloats(Object rowArray, int rowOffset, ShortBuffer buffer, int bufferElementOffset, int length) {
+		final float[] floatData = (float[]) rowArray;
+		for (int i = 0; i < length; i++) {
+			floatData[rowOffset + i] = toFloat(buffer.get(bufferElementOffset + i));
+		}
+	}
+
 	private static void fillData(Object data, int[] dims, ShortBuffer buffer) {
 		if (dims.length > 1) {
 			for (int i = 0; i < dims[0]; i++) {


### PR DESCRIPTION
Previously chunked datasets were read in two phases: all chunks were decompressed in parallel into an intermediate byte array, then that array was converted into the final typed (int/float/double etc.) array in a second serial pass.

Now the correctly typed and sized output array is created up front and each chunk is read, decompressed (unfiltered), converted into the correct type and written directly into its location in the output array, with multiple threads writing to the array in parallel. This removes the intermediate full-dataset byte array and the serial conversion pass.

DataType implementations declare support via supportsDirectFill() and implement fillElements() to convert a run of elements from a decompressed chunk buffer into an innermost row of the output array. FixedPoint (signed and unsigned) and FloatingPoint (including half precision) support it; all other types fall back to the previous buffer then convert path unchanged.