### PR TITLE
Add JMH benchmark for large chunked dataset reads

### DIFF
--- a/jhdf/.gitignore
+++ b/jhdf/.gitignore
@@ -5,6 +5,9 @@
 /.gradle
 /build
 
+# Large data files downloaded for JMH benchmarks (see src/jmh/resources/README.md)
+/src/jmh/resources/*.hdf5
+
 # Eclipse
 /.settings
 .classpath

--- a/jhdf/build.gradle
+++ b/jhdf/build.gradle
@@ -132,6 +132,14 @@ jacocoTestReport {
     }
 }
 
+// The main and test source sets both bundle a simplelogger.properties (info/debug). When the
+// fat JMH jar merges resources they collide and the test one (debug) wins, flooding the
+// benchmarks with per-chunk debug logging. Exclude both; slf4j-simple then defaults to info.
+// When running via './gradlew jmh' the copy in src/jmh/resources (warn) is used instead.
+jmhJar {
+    exclude('simplelogger.properties')
+}
+
 task sourcesJar(type: Jar) {
     from sourceSets.main.allJava
     archiveClassifier = 'sources'

--- a/jhdf/src/jmh/java/io/jhdf/benchmarks/ChunkedDatasetReadBenchmark.java
+++ b/jhdf/src/jmh/java/io/jhdf/benchmarks/ChunkedDatasetReadBenchmark.java
@@ -1,0 +1,146 @@
+/*
+ * This file is part of jHDF. A pure Java library for accessing HDF5 files.
+ *
+ * https://jhdf.io
+ *
+ * Copyright (c) 2025 James Mudd
+ *
+ * MIT License see 'LICENSE' file
+ */
+
+package io.jhdf.benchmarks;
+
+import io.jhdf.HdfFile;
+import io.jhdf.api.Dataset;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmarks reading slices from a large real-world chunked dataset. The data
+ * file is not committed to git, download it by running
+ * {@code src/jmh/resources/download_benchmark_data.py} (see
+ * {@code src/jmh/resources/README.md}).
+ * <p>
+ * The dataset is {@code Experiments/__unnamed__/data} from the Zenodo record
+ * <a href="https://doi.org/10.5281/zenodo.19882183">10.5281/zenodo.19882183</a>:
+ * <ul>
+ *     <li>shape (255, 255, 257, 257) uint8 (~4 GiB uncompressed)</li>
+ *     <li>chunk shape (2, 4, 257, 257) (~516 KiB per chunk uncompressed)</li>
+ *     <li>gzip compressed</li>
+ * </ul>
+ * Reading the whole dataset at once is deliberately not benchmarked, it
+ * decompresses to ~4 GiB of small Java arrays which dominates the measurement
+ * with allocation/GC noise. Instead slices of increasing size and alignment
+ * are measured.
+ * <p>
+ * The file location can be overridden with the system property
+ * {@code jmh.benchmark.data} or the environment variable
+ * {@code JMH_BENCHMARK_DATA}.
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 3)
+@Measurement(iterations = 5, time = 3)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(2)
+public class ChunkedDatasetReadBenchmark {
+
+	private static final String DATASET_PATH = "Experiments/__unnamed__/data";
+	private static final String DEFAULT_FILE = "src/jmh/resources/stem_data_binned2.hdf5";
+
+	private HdfFile hdfFile;
+	private Dataset dataset;
+
+	@Setup(Level.Trial)
+	public void setup() {
+		Path path = resolveDataFile();
+		hdfFile = new HdfFile(path);
+		dataset = hdfFile.getDatasetByPath(DATASET_PATH);
+	}
+
+	@TearDown(Level.Trial)
+	public void tearDown() {
+		hdfFile.close();
+	}
+
+	/**
+	 * Reads exactly one chunk (2, 4, 257, 257) = ~516 KiB decompressed.
+	 */
+	@Benchmark
+	public void readSingleChunk(Blackhole blackhole) {
+		blackhole.consume(dataset.getData(new long[]{120, 120, 0, 0}, new int[]{2, 4, 257, 257}));
+	}
+
+	/**
+	 * Reads a single detector frame (1, 1, 257, 257) = ~64 KiB decompressed.
+	 * A partial chunk read, the containing chunk must be fetched and decoded.
+	 */
+	@Benchmark
+	public void readSingleFrame(Blackhole blackhole) {
+		blackhole.consume(dataset.getData(new long[]{100, 100, 0, 0}, new int[]{1, 1, 257, 257}));
+	}
+
+	/**
+	 * Reads one full row (1, 255, 257, 257) = ~16 MiB decompressed, spanning
+	 * all 64 chunk columns of the dataset.
+	 */
+	@Benchmark
+	public void readRowAcrossChunks(Blackhole blackhole) {
+		blackhole.consume(dataset.getData(new long[]{7, 0, 0, 0}, new int[]{1, 255, 257, 257}));
+	}
+
+	/**
+	 * Reads a chunk grid aligned slab (16, 255, 257, 257) = ~256 MiB
+	 * decompressed, 512 chunks.
+	 */
+	@Benchmark
+	public void readAlignedSlab(Blackhole blackhole) {
+		blackhole.consume(dataset.getData(new long[]{32, 0, 0, 0}, new int[]{16, 255, 257, 257}));
+	}
+
+	/**
+	 * Reads the same size slab as {@link #readAlignedSlab} but offset by 1 in
+	 * the first 2 dimensions so every chunk contributes only partially,
+	 * exercising the slice extraction path.
+	 */
+	@Benchmark
+	public void readUnalignedSlab(Blackhole blackhole) {
+		blackhole.consume(dataset.getData(new long[]{31, 1, 0, 0}, new int[]{16, 254, 257, 257}));
+	}
+
+	private static Path resolveDataFile() {
+		String fromProperty = System.getProperty("jmh.benchmark.data");
+		if (fromProperty != null) {
+			return Paths.get(fromProperty);
+		}
+		String fromEnv = System.getenv("JMH_BENCHMARK_DATA");
+		if (fromEnv != null) {
+			return Paths.get(fromEnv);
+		}
+		Path path = Paths.get(DEFAULT_FILE).toAbsolutePath();
+		if (!Files.exists(path)) {
+			throw new IllegalStateException(
+				"Benchmark data file not found: " + path + System.lineSeparator() +
+					"Download it by running: python3 src/jmh/resources/download_benchmark_data.py" + System.lineSeparator() +
+					"Or set -Djmh.benchmark.data=/path/to/stem_data_binned2.hdf5");
+		}
+		return path;
+	}
+
+}

--- a/jhdf/src/jmh/resources/README.md
+++ b/jhdf/src/jmh/resources/README.md
@@ -1,0 +1,29 @@
+# JMH benchmark data
+
+The large data files used by the JMH benchmarks are **not** committed to git.
+To download them run:
+
+```bash
+python3 src/jmh/resources/download_benchmark_data.py
+```
+
+from the `jhdf` project directory (or run the script from anywhere, it writes
+next to itself).
+
+## `stem_data_binned2.hdf5` (~368 MiB)
+
+Used by `ChunkedDatasetReadBenchmark`. Real-world large chunked dataset from
+Zenodo, record [19882183](https://zenodo.org/records/19882183) (DOI:
+10.5281/zenodo.19882183, CC-BY-4.0): *Scanning transmission electron
+microscopy data of polymer blend semiconductors F8:F8BT*.
+
+| Property | Value |
+|---|---|
+| Dataset path | `Experiments/__unnamed__/data` |
+| Shape | `(255, 255, 257, 257)` (~4 GiB uncompressed) |
+| Type | `uint8` |
+| Chunk shape | `(2, 4, 257, 257)` (~516 KiB per chunk uncompressed) |
+| Compression | gzip |
+
+The file can be placed elsewhere and passed to the benchmark with
+`-Djmh.benchmark.data=/path/to/stem_data_binned2.hdf5`.

--- a/jhdf/src/jmh/resources/download_benchmark_data.py
+++ b/jhdf/src/jmh/resources/download_benchmark_data.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# -------------------------------------------------------------------------------
+# This file is part of jHDF. A pure Java library for accessing HDF5 files.
+#
+# https://jhdf.io
+#
+# Copyright (c) 2025 James Mudd
+#
+# MIT License see 'LICENSE' file
+# -------------------------------------------------------------------------------
+"""Downloads the large chunked HDF5 dataset used by ChunkedDatasetReadBenchmark.
+
+The file is fetched from Zenodo (found using the search approach in
+jhdf/src/test/resources/scripts/zenodo.py):
+
+  Record : 19882183 - Scanning transmission electron microscopy data of
+           polymer blend semiconductors F8:F8BT
+  DOI    : 10.5281/zenodo.19882183
+  License: CC-BY-4.0
+  File   : 20230722_105647_data_binned2.hdf5 (368 MiB)
+
+The file contains a 4D chunked, gzip compressed dataset:
+
+  Experiments/__unnamed__/data
+      shape  = (255, 255, 257, 257)  (~4 GiB uncompressed)
+      dtype  = uint8
+      chunks = (2, 4, 257, 257)      (~516 KiB per chunk uncompressed)
+      compression = gzip
+
+Usage:
+    python3 src/jmh/resources/download_benchmark_data.py
+
+The download is verified against the MD5 checksum published by Zenodo.
+"""
+
+import hashlib
+import sys
+from pathlib import Path
+
+import requests
+
+ZENODO_URL = (
+    "https://zenodo.org/api/records/19882183/files/20230722_105647_data_binned2.hdf5/content"
+)
+EXPECTED_MD5 = "d99b3ee896ccbee5e59e35c456008110"
+EXPECTED_SIZE = 386_328_553  # bytes
+
+OUTPUT_FILE = Path(__file__).parent / "stem_data_binned2.hdf5"
+
+
+def download():
+    print(f"Downloading {ZENODO_URL}")
+    print(f"        -> {OUTPUT_FILE}")
+    md5 = hashlib.md5()
+    size = 0
+    with requests.get(ZENODO_URL, stream=True) as response:
+        response.raise_for_status()
+        with open(OUTPUT_FILE, "wb") as f:
+            for chunk in response.iter_content(chunk_size=8 * 1024 * 1024):
+                f.write(chunk)
+                md5.update(chunk)
+                size += len(chunk)
+                print(f"\r{size / 1e6:.0f} / {EXPECTED_SIZE / 1e6:.0f} MB", end="", flush=True)
+    print()
+
+    if size != EXPECTED_SIZE:
+        sys.exit(f"FAILED: size mismatch {size} != {EXPECTED_SIZE}")
+    if md5.hexdigest() != EXPECTED_MD5:
+        sys.exit(f"FAILED: md5 mismatch {md5.hexdigest()} != {EXPECTED_MD5}")
+    print("Checksum OK")
+
+
+if __name__ == "__main__":
+    if OUTPUT_FILE.exists():
+        print(f"{OUTPUT_FILE} already exists, delete it to re-download")
+    else:
+        download()

--- a/jhdf/src/jmh/resources/simplelogger.properties
+++ b/jhdf/src/jmh/resources/simplelogger.properties
@@ -1,0 +1,15 @@
+#-------------------------------------------------------------------------------
+# This file is part of jHDF. A pure Java library for accessing HDF5 files.
+#
+# https://jhdf.io
+#
+# Copyright (c) 2025 James Mudd
+#
+# MIT License see 'LICENSE' file
+#-------------------------------------------------------------------------------
+
+# Keep logging quiet during benchmarks, debug logging is per chunk and would
+# dominate the measurements (the test resources enable debug logging)
+org.slf4j.simpleLogger.logFile=System.out
+org.slf4j.simpleLogger.defaultLogLevel=warn
+org.slf4j.simpleLogger.cacheOutputStream=true


### PR DESCRIPTION
Adds ChunkedDatasetReadBenchmark measuring sliced reads from a real-world large chunked dataset: the 368 MiB gzip compressed 4D STEM dataset from Zenodo record 19882183 (10.5281/zenodo.19882183, CC-BY-4.0), chunk shape (2, 4, 257, 257) over a (255, 255, 257, 257) uint8 dataset.

Benchmarks single chunk, partial chunk (frame), row across all chunk columns, and 256 MiB aligned/unaligned slab reads.

The data file is not committed; download_benchmark_data.py fetches and checksum-verifies it (found using the approach in
src/test/resources/scripts/zenodo.py). Also excludes the colliding simplelogger.properties from the fat JMH jar so per-chunk debug logging does not dominate measurements.