### PR TITLE
Write a chunked dataset from a ChunkProvider, so it need not fit in memory

### DIFF
--- a/jhdf/build.gradle
+++ b/jhdf/build.gradle
@@ -90,6 +90,10 @@ test {
         events "passed", "skipped", "failed"
     }
 
+    // Opt in to tests that write multi gigabyte files, which are too slow and too large for a normal run.
+    // Forwarded from the Gradle JVM because the tests run forked: ./gradlew test -Djhdf.test.largeWrite=true
+    systemProperty 'jhdf.test.largeWrite', System.getProperty('jhdf.test.largeWrite', 'false')
+
 minHeapSize = "128m" // initial heap size
 maxHeapSize = "8192m" // maximum heap size
 //jvmArgs '-XX:MaxPermSize=5gb' // mem argument for the test JVM

--- a/jhdf/src/main/java/io/jhdf/WritableDatasetImpl.java
+++ b/jhdf/src/main/java/io/jhdf/WritableDatasetImpl.java
@@ -11,6 +11,7 @@
 package io.jhdf;
 
 import io.jhdf.api.Attribute;
+import io.jhdf.api.ChunkProvider;
 import io.jhdf.api.DatasetCreationOptions;
 import io.jhdf.api.Group;
 import io.jhdf.api.NodeType;
@@ -51,6 +52,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static io.jhdf.Utils.flatten;
 import static io.jhdf.Utils.stripLeadingIndex;
@@ -61,6 +63,8 @@ public class WritableDatasetImpl extends AbstractWritableNode implements Writabl
 	private static final Logger logger = LoggerFactory.getLogger(WritableDatasetImpl.class);
 
 	private final Object data;
+	/** Supplies chunks on demand instead of holding the whole dataset, null when data is held in memory */
+	private final ChunkProvider chunkProvider;
 	private final DataType dataType;
 
 	private final DataSpace dataSpace;
@@ -79,6 +83,7 @@ public class WritableDatasetImpl extends AbstractWritableNode implements Writabl
 	public WritableDatasetImpl(Object data, String name, Group parent, DatasetCreationOptions options) {
 		super(parent, name);
 		this.data = data;
+		this.chunkProvider = null;
 		if (options == null) {
 			options = DatasetCreationOptions.DEFAULT;
 		}
@@ -86,6 +91,45 @@ public class WritableDatasetImpl extends AbstractWritableNode implements Writabl
 		this.dataSpace = DataSpace.fromObject(data);
 		this.chunkDimensions = resolveChunkDimensions(options);
 		this.requestedFilters = chunkDimensions != null ? options.getFilters() : Collections.emptyList();
+	}
+
+	/**
+	 * Creates a chunked dataset whose data is supplied a chunk at a time, so it is never held in memory as a whole.
+	 *
+	 * @param javaType the dataset's element type e.g. {@code double.class}
+	 * @param dimensions the dataset's dimensions
+	 * @param name the dataset name
+	 * @param parent the parent group
+	 * @param options must specify chunk dimensions
+	 * @param chunkProvider supplies each chunk when the file is written
+	 */
+	public WritableDatasetImpl(Class<?> javaType, int[] dimensions, String name, Group parent,
+							   DatasetCreationOptions options, ChunkProvider chunkProvider) {
+		super(parent, name);
+		this.data = null;
+		this.chunkProvider = Objects.requireNonNull(chunkProvider, "chunkProvider cannot be null");
+		Objects.requireNonNull(javaType, "javaType cannot be null");
+		if (dimensions == null || dimensions.length == 0) {
+			throw new HdfWritingException("Dimensions must be provided for a chunk provider dataset");
+		}
+		for (int dimension : dimensions) {
+			if (dimension < 1) {
+				throw new HdfWritingException("Dimensions " + Arrays.toString(dimensions) + " must all be positive");
+			}
+		}
+		if (options == null || !options.isChunked()) {
+			throw new HdfWritingException("Chunk dimensions must be specified to write a dataset from a chunk provider");
+		}
+		// A single element of the requested type and rank is enough to derive the data type and a dataspace of the
+		// right rank, without allocating anything proportional to the dataset. It must not be zero length in any
+		// dimension because the type is found by walking into the array.
+		final int[] oneOfEach = new int[dimensions.length];
+		Arrays.fill(oneOfEach, 1);
+		final Object prototype = Array.newInstance(javaType, oneOfEach);
+		this.dataType = DataType.fromObject(prototype, options.isUnsigned());
+		this.dataSpace = DataSpace.modifyDimensions(DataSpace.fromObject(prototype), dimensions);
+		this.chunkDimensions = resolveChunkDimensions(options);
+		this.requestedFilters = options.getFilters();
 	}
 
 	private int[] resolveChunkDimensions(DatasetCreationOptions options) {
@@ -126,10 +170,12 @@ public class WritableDatasetImpl extends AbstractWritableNode implements Writabl
 				+ Arrays.toString(resolvedChunkDimensions), e);
 		}
 
-		// Writing chunks encodes the full dataset into a single buffer first
-		if (dataSpace.getTotalLength() * dataType.getSize() > Integer.MAX_VALUE) {
+		// Slicing chunks out of memory encodes the full dataset into a single buffer first. A chunk provider never
+		// does that, so the limit is per chunk (checked above) rather than per dataset.
+		if (chunkProvider == null && dataSpace.getTotalLength() * dataType.getSize() > Integer.MAX_VALUE) {
 			throw new HdfWritingException("Dataset is too large to write chunked. Maximum is ["
-				+ Integer.MAX_VALUE + "] bytes");
+				+ Integer.MAX_VALUE + "] bytes, supply the data with a "
+				+ ChunkProvider.class.getSimpleName() + " to write a larger dataset");
 		}
 
 		return resolvedChunkDimensions;
@@ -182,7 +228,7 @@ public class WritableDatasetImpl extends AbstractWritableNode implements Writabl
 
 	@Override
 	public boolean isEmpty() {
-		return data == null;
+		return data == null && chunkProvider == null;
 	}
 
 	@Override
@@ -214,11 +260,13 @@ public class WritableDatasetImpl extends AbstractWritableNode implements Writabl
 
 	@Override
 	public Object getData() {
+		requireDataInMemory();
 		return data;
 	}
 
 	@Override
 	public Object getDataFlat() {
+		requireDataInMemory();
 		return flatten(data);
 	}
 
@@ -439,6 +487,33 @@ public class WritableDatasetImpl extends AbstractWritableNode implements Writabl
 			chunkSizeInBytes);
 	}
 
+	/**
+	 * A {@link ChunkSource} that asks the {@link ChunkProvider} for each chunk as it is written.
+	 */
+	private ChunkSource providerChunkSource(int chunkSizeInBytes) {
+		return chunkOffset -> {
+			final Object chunkData = chunkProvider.getChunk(chunkOffset);
+			if (chunkData == null) {
+				throw new HdfWritingException("No data supplied for the chunk at offset "
+					+ Arrays.toString(chunkOffset) + " of dataset [" + getPath() + "]");
+			}
+			final byte[] chunkBytes = dataType.encodeData(chunkData).array();
+			if (chunkBytes.length != chunkSizeInBytes) {
+				throw new HdfWritingException("The chunk at offset " + Arrays.toString(chunkOffset) + " of dataset ["
+					+ getPath() + "] encoded to [" + chunkBytes.length + "] bytes, expected [" + chunkSizeInBytes
+					+ "] bytes for chunk dimensions " + Arrays.toString(chunkDimensions));
+			}
+			return chunkBytes;
+		};
+	}
+
+	private void requireDataInMemory() {
+		if (chunkProvider != null) {
+			throw new HdfWritingException("Dataset [" + getPath() + "] is written from a "
+				+ ChunkProvider.class.getSimpleName() + " so its data is not held in memory");
+		}
+	}
+
 	private static final class ChunkedDataResult {
 		private final DataLayoutMessage dataLayoutMessage;
 		private final long endPosition;
@@ -458,7 +533,9 @@ public class WritableDatasetImpl extends AbstractWritableNode implements Writabl
 		final int totalChunks = getTotalChunks();
 		final boolean filtered = !filterInfos.isEmpty();
 
-		final ChunkSource chunkSource = inMemoryChunkSource(datasetDimensions, elementSize, chunkSizeInBytes);
+		final ChunkSource chunkSource = chunkProvider == null
+			? inMemoryChunkSource(datasetDimensions, elementSize, chunkSizeInBytes)
+			: providerChunkSource(chunkSizeInBytes);
 
 		final List<Chunk> chunks = new ArrayList<>(totalChunks);
 		long address = dataAddress;

--- a/jhdf/src/main/java/io/jhdf/WritableDatasetImpl.java
+++ b/jhdf/src/main/java/io/jhdf/WritableDatasetImpl.java
@@ -412,6 +412,33 @@ public class WritableDatasetImpl extends AbstractWritableNode implements Writabl
 		return Math.max(10, bitsNeeded);
 	}
 
+	/**
+	 * Supplies the raw, unfiltered, fully padded bytes of a single chunk.
+	 * <p>
+	 * Chunks are written to the file one at a time already; the only thing forcing the whole dataset into memory
+	 * is where those bytes come from. Naming that dependency lets a chunk be produced on demand instead of
+	 * sliced out of a buffer holding everything.
+	 *
+	 * @see #inMemoryChunkSource(int[], int, int)
+	 */
+	@FunctionalInterface
+	interface ChunkSource {
+		/**
+		 * @param chunkOffset the offset of the chunk within the dataset
+		 * @return exactly {@code chunkSizeInBytes} bytes, zero padded where the chunk overhangs the dataset
+		 */
+		byte[] chunkBytes(long[] chunkOffset);
+	}
+
+	/**
+	 * A {@link ChunkSource} that slices chunks out of the whole dataset encoded in memory.
+	 */
+	private ChunkSource inMemoryChunkSource(int[] datasetDimensions, int elementSize, int chunkSizeInBytes) {
+		final byte[] flatData = dataType.encodeData(data).array();
+		return chunkOffset -> extractChunk(flatData, datasetDimensions, chunkDimensions, chunkOffset, elementSize,
+			chunkSizeInBytes);
+	}
+
 	private static final class ChunkedDataResult {
 		private final DataLayoutMessage dataLayoutMessage;
 		private final long endPosition;
@@ -431,15 +458,14 @@ public class WritableDatasetImpl extends AbstractWritableNode implements Writabl
 		final int totalChunks = getTotalChunks();
 		final boolean filtered = !filterInfos.isEmpty();
 
-		// Encode the full dataset into a flat row major buffer then slice it into chunks
-		final byte[] flatData = dataType.encodeData(data).array();
+		final ChunkSource chunkSource = inMemoryChunkSource(datasetDimensions, elementSize, chunkSizeInBytes);
 
 		final List<Chunk> chunks = new ArrayList<>(totalChunks);
 		long address = dataAddress;
 		for (int chunkIndex = 0; chunkIndex < totalChunks; chunkIndex++) {
 			final long[] chunkOffset = Utils.chunkIndexToChunkOffset((long) chunkIndex, chunkDimensions, datasetDimensions);
 
-			byte[] chunkBytes = extractChunk(flatData, datasetDimensions, chunkDimensions, chunkOffset, elementSize, chunkSizeInBytes);
+			byte[] chunkBytes = chunkSource.chunkBytes(chunkOffset);
 			chunkBytes = applyFilters(chunkBytes, filterInfos);
 
 			writeFully(hdfFileChannel, ByteBuffer.wrap(chunkBytes), address);

--- a/jhdf/src/main/java/io/jhdf/WritableGroupImpl.java
+++ b/jhdf/src/main/java/io/jhdf/WritableGroupImpl.java
@@ -12,6 +12,7 @@ package io.jhdf;
 
 import io.jhdf.api.Attribute;
 import io.jhdf.api.Dataset;
+import io.jhdf.api.ChunkProvider;
 import io.jhdf.api.DatasetCreationOptions;
 import io.jhdf.api.Group;
 import io.jhdf.api.Node;
@@ -137,6 +138,20 @@ public class WritableGroupImpl extends AbstractWritableNode implements WritableG
     WritableDataset writableDataset = new WritableDatasetImpl(data, name, this, options);
     children.put(name, writableDataset);
     logger.info("Added dataset [{}] to group [{}]", name, getPath());
+    return writableDataset;
+  }
+
+  @Override
+  public WritableDataset putDataset(String name, Class<?> javaType, int[] dimensions,
+      DatasetCreationOptions options, ChunkProvider chunkProvider) {
+    if (StringUtils.isBlank(name)) {
+      throw new IllegalArgumentException("name cannot be null or blank");
+    }
+
+    WritableDataset writableDataset =
+        new WritableDatasetImpl(javaType, dimensions, name, this, options, chunkProvider);
+    children.put(name, writableDataset);
+    logger.info("Added chunk provider dataset [{}] to group [{}]", name, getPath());
     return writableDataset;
   }
 

--- a/jhdf/src/main/java/io/jhdf/WritableHdfFile.java
+++ b/jhdf/src/main/java/io/jhdf/WritableHdfFile.java
@@ -12,6 +12,7 @@ package io.jhdf;
 
 import io.jhdf.api.Attribute;
 import io.jhdf.api.Dataset;
+import io.jhdf.api.ChunkProvider;
 import io.jhdf.api.DatasetCreationOptions;
 import io.jhdf.api.Group;
 import io.jhdf.api.Node;
@@ -112,6 +113,15 @@ public class WritableHdfFile implements WritableGroup, AutoCloseable {
 	@Override
 	public WritableDataset putDataset(String name, Object data, DatasetCreationOptions options) {
 		return rootGroup.putDataset(name, data, options);
+	}
+
+	/**
+	 {@inheritDoc}
+	 */
+	@Override
+	public WritableDataset putDataset(String name, Class<?> javaType, int[] dimensions,
+									  DatasetCreationOptions options, ChunkProvider chunkProvider) {
+		return rootGroup.putDataset(name, javaType, dimensions, options, chunkProvider);
 	}
 
 	/**

--- a/jhdf/src/main/java/io/jhdf/api/ChunkProvider.java
+++ b/jhdf/src/main/java/io/jhdf/api/ChunkProvider.java
@@ -1,0 +1,40 @@
+/*
+ * This file is part of jHDF. A pure Java library for accessing HDF5 files.
+ *
+ * https://jhdf.io
+ *
+ * Copyright (c) 2026 James Mudd
+ *
+ * MIT License see 'LICENSE' file
+ */
+package io.jhdf.api;
+
+/**
+ * Supplies a chunked dataset's data one chunk at a time.
+ * <p>
+ * Passing a dataset to {@link WritableGroup#putDataset(String, Object)} requires the whole thing to be in memory,
+ * which puts an upper bound on what can be written. A {@code ChunkProvider} is asked for one chunk at a time while
+ * the file is written, so the memory needed is that of a single chunk rather than the whole dataset. This suits
+ * data that is read from elsewhere or generated on demand.
+ * <p>
+ * Every chunk of the dataset is requested exactly once, so the provider must be able to supply any chunk; returning
+ * {@code null} is an error and fails the write.
+ *
+ * @since v0.14.0
+ */
+@FunctionalInterface
+public interface ChunkProvider {
+
+	/**
+	 * Provides the data for a single chunk.
+	 * <p>
+	 * The returned array must have the chunk dimensions given in the {@link DatasetCreationOptions} and hold the
+	 * dataset's type, so for a {@code double} dataset with chunk dimensions {@code {16, 32}} it is a
+	 * {@code double[16][32]}. Where a chunk overhangs the edge of the dataset it is still a whole chunk; the
+	 * values outside the dataset are stored but never read back.
+	 *
+	 * @param chunkOffset the offset of this chunk within the dataset, one element per dimension
+	 * @return the chunk's data, never {@code null}
+	 */
+	Object getChunk(long[] chunkOffset);
+}

--- a/jhdf/src/main/java/io/jhdf/api/WritableGroup.java
+++ b/jhdf/src/main/java/io/jhdf/api/WritableGroup.java
@@ -36,6 +36,22 @@ public interface WritableGroup extends Group, WritableNode {
 	 */
 	WritableDataset putDataset(String name, Object data, DatasetCreationOptions options);
 
+	/**
+	 Put a named chunked dataset into the group whose data is supplied one chunk at a time, so a dataset larger
+	 than memory can be written. The dataset's shape and type are given here rather than inferred, because no data
+	 object exists yet; the {@link ChunkProvider} is asked for every chunk while the file is written.
+
+	 * @param name The dataset name within this group
+	 * @param javaType The dataset's element type e.g. {@code double.class}
+	 * @param dimensions The dataset's dimensions
+	 * @param options Options controlling how the dataset is stored, must specify chunk dimensions
+	 * @param chunkProvider Supplies each chunk when the file is written
+	 * @return the dataset, for further modification
+	 * @since v0.14.0
+	 */
+	WritableDataset putDataset(String name, Class<?> javaType, int[] dimensions, DatasetCreationOptions options,
+							   ChunkProvider chunkProvider);
+
 	WritableGroup putGroup(String name);
 
 }

--- a/jhdf/src/test/java/io/jhdf/writing/ChunkProviderWritingTest.java
+++ b/jhdf/src/test/java/io/jhdf/writing/ChunkProviderWritingTest.java
@@ -1,0 +1,276 @@
+/*
+ * This file is part of jHDF. A pure Java library for accessing HDF5 files.
+ *
+ * https://jhdf.io
+ *
+ * Copyright (c) 2026 James Mudd
+ *
+ * MIT License see 'LICENSE' file
+ */
+
+package io.jhdf.writing;
+
+import io.jhdf.HdfFile;
+import io.jhdf.WritableDatasetImpl;
+import io.jhdf.WritableHdfFile;
+import io.jhdf.api.ChunkProvider;
+import io.jhdf.api.Dataset;
+import io.jhdf.api.DatasetCreationOptions;
+import io.jhdf.exceptions.HdfWritingException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Writing a chunked dataset from a {@link ChunkProvider}, so the whole dataset is never in memory.
+ */
+class ChunkProviderWritingTest {
+
+	private static double[][][] doubleData3d(int i, int j, int k) {
+		double[][][] data = new double[i][j][k];
+		for (int a = 0; a < i; a++) {
+			for (int b = 0; b < j; b++) {
+				for (int c = 0; c < k; c++) {
+					data[a][b][c] = a * 100.0 + b * 10.0 + c + 0.5;
+				}
+			}
+		}
+		return data;
+	}
+
+	/** Slices chunks out of an in memory dataset, standing in for an application reading them from elsewhere. */
+	private static ChunkProvider sliceOf(double[][][] data, int[] chunkDimensions) {
+		return chunkOffset -> {
+			double[][][] chunk = new double[chunkDimensions[0]][chunkDimensions[1]][chunkDimensions[2]];
+			for (int a = 0; a < chunkDimensions[0]; a++) {
+				for (int b = 0; b < chunkDimensions[1]; b++) {
+					for (int c = 0; c < chunkDimensions[2]; c++) {
+						int i = Math.toIntExact(chunkOffset[0]) + a;
+						int j = Math.toIntExact(chunkOffset[1]) + b;
+						int k = Math.toIntExact(chunkOffset[2]) + c;
+						// Chunks overhanging the dataset keep the zero padding
+						if (i < data.length && j < data[0].length && k < data[0][0].length) {
+							chunk[a][b][c] = data[i][j][k];
+						}
+					}
+				}
+			}
+			return chunk;
+		};
+	}
+
+	private Path writeWithProvider(double[][][] data, int[] chunkDimensions, DatasetCreationOptions options)
+		throws IOException {
+		Path file = Files.createTempFile("provider", ".hdf5");
+		try (WritableHdfFile writableHdfFile = HdfFile.write(file)) {
+			writableHdfFile.putDataset("data", double.class,
+				new int[]{data.length, data[0].length, data[0][0].length}, options, sliceOf(data, chunkDimensions));
+		}
+		return file;
+	}
+
+	private Path writeInMemory(double[][][] data, DatasetCreationOptions options) throws IOException {
+		Path file = Files.createTempFile("inMemory", ".hdf5");
+		try (WritableHdfFile writableHdfFile = HdfFile.write(file)) {
+			writableHdfFile.putDataset("data", data, options);
+		}
+		return file;
+	}
+
+	/**
+	 * The strongest statement available that supplying chunks changes nothing: for a dataset small enough to write
+	 * both ways, the two files are identical.
+	 */
+	@Test
+	void providedChunksProduceTheSameFileAsWritingTheWholeDataset() throws Exception {
+		double[][][] data = doubleData3d(6, 8, 10);
+		int[] chunkDimensions = {2, 4, 5}; // divides the dataset exactly
+		DatasetCreationOptions options = DatasetCreationOptions.builder().chunkDimensions(chunkDimensions).build();
+
+		assertArrayEquals(
+			Files.readAllBytes(writeInMemory(data, options)),
+			Files.readAllBytes(writeWithProvider(data, chunkDimensions, options)));
+	}
+
+	@Test
+	void providedChunksMatchWithPartialEdgeChunks() throws Exception {
+		double[][][] data = doubleData3d(7, 9, 11);
+		int[] chunkDimensions = {2, 4, 5}; // overhangs the dataset in every dimension
+		DatasetCreationOptions options = DatasetCreationOptions.builder().chunkDimensions(chunkDimensions).build();
+
+		assertArrayEquals(
+			Files.readAllBytes(writeInMemory(data, options)),
+			Files.readAllBytes(writeWithProvider(data, chunkDimensions, options)));
+	}
+
+	@Test
+	void providedChunksMatchWithFilters() throws Exception {
+		double[][][] data = doubleData3d(6, 8, 10);
+		int[] chunkDimensions = {2, 4, 5};
+		DatasetCreationOptions options = DatasetCreationOptions.builder()
+			.chunkDimensions(chunkDimensions).shuffle().deflate(4).build();
+
+		assertArrayEquals(
+			Files.readAllBytes(writeInMemory(data, options)),
+			Files.readAllBytes(writeWithProvider(data, chunkDimensions, options)));
+	}
+
+	@Test
+	void providedDataReadsBackCorrectly() throws Exception {
+		double[][][] data = doubleData3d(6, 8, 10);
+		int[] chunkDimensions = {2, 4, 5};
+		Path file = writeWithProvider(data, chunkDimensions,
+			DatasetCreationOptions.builder().chunkDimensions(chunkDimensions).deflate(4).build());
+
+		try (HdfFile hdfFile = new HdfFile(file)) {
+			Dataset dataset = hdfFile.getDatasetByPath("data");
+			assertThat(dataset.getDimensions(), is(new int[]{6, 8, 10}));
+			assertThat(dataset.getData(), is(data));
+		}
+	}
+
+	/** Every chunk exactly once, so a provider can be a cursor over an external source without bookkeeping. */
+	@Test
+	void everyChunkIsRequestedExactlyOnce() throws Exception {
+		double[][][] data = doubleData3d(6, 8, 10);
+		int[] chunkDimensions = {2, 4, 5};
+		ChunkProvider delegate = sliceOf(data, chunkDimensions);
+		List<String> requested = new ArrayList<>();
+
+		Path file = Files.createTempFile("counted", ".hdf5");
+		try (WritableHdfFile writableHdfFile = HdfFile.write(file)) {
+			writableHdfFile.putDataset("data", double.class, new int[]{6, 8, 10},
+				DatasetCreationOptions.builder().chunkDimensions(chunkDimensions).build(),
+				chunkOffset -> {
+					requested.add(Arrays.toString(chunkOffset));
+					return delegate.getChunk(chunkOffset);
+				});
+		}
+
+		Set<String> unique = new HashSet<>(requested);
+		assertThat(requested.size(), is(3 * 2 * 2)); // 6/2 * 8/4 * 10/5
+		assertThat(unique.size(), is(requested.size()));
+	}
+
+	@Test
+	void aChunkThatIsNotSuppliedFailsTheWrite() throws Exception {
+		Path file = Files.createTempFile("missing", ".hdf5");
+		WritableHdfFile writableHdfFile = HdfFile.write(file);
+		writableHdfFile.putDataset("data", double.class, new int[]{4, 4},
+			DatasetCreationOptions.builder().chunkDimensions(2, 2).build(),
+			chunkOffset -> chunkOffset[0] == 0 ? new double[2][2] : null);
+
+		HdfWritingException exception = assertThrows(HdfWritingException.class, writableHdfFile::close);
+		assertThat(exception.getMessage(), containsString("No data supplied for the chunk at offset"));
+	}
+
+	@Test
+	void aWrongShapedChunkFailsTheWrite() throws Exception {
+		Path file = Files.createTempFile("wrongShape", ".hdf5");
+		WritableHdfFile writableHdfFile = HdfFile.write(file);
+		writableHdfFile.putDataset("data", double.class, new int[]{4, 4},
+			DatasetCreationOptions.builder().chunkDimensions(2, 2).build(),
+			chunkOffset -> new double[3][3]);
+
+		HdfWritingException exception = assertThrows(HdfWritingException.class, writableHdfFile::close);
+		assertThat(exception.getMessage(), containsString("expected [32] bytes for chunk dimensions [2, 2]"));
+	}
+
+	@Test
+	void chunkDimensionsAreRequired() throws Exception {
+		Path file = Files.createTempFile("noChunks", ".hdf5");
+		try (WritableHdfFile writableHdfFile = HdfFile.write(file)) {
+			HdfWritingException exception = assertThrows(HdfWritingException.class, () ->
+				writableHdfFile.putDataset("data", double.class, new int[]{4, 4},
+					DatasetCreationOptions.DEFAULT, chunkOffset -> new double[2][2]));
+			assertThat(exception.getMessage(), containsString("Chunk dimensions must be specified"));
+			writableHdfFile.putDataset("placeholder", new int[]{1});
+		}
+	}
+
+	/**
+	 * The point of the feature: a dataset too large to hold in memory can still be declared. Writing 2 GB of it
+	 * would make this test unreasonably slow, so this asserts only that the limit which exists purely because the
+	 * in memory path buffers everything no longer applies.
+	 */
+	@Test
+	void aDatasetLargerThanTheInMemoryLimitCanBeDeclared() throws Exception {
+		Path file = Files.createTempFile("large", ".hdf5");
+		try (WritableHdfFile writableHdfFile = HdfFile.write(file)) {
+			int[] dimensions = {1024, 1024, 512}; // 4 GiB of doubles, four times the in memory limit
+
+			// Constructed rather than put into the file, so closing does not write 4 GiB. Writing a dataset that
+			// size for real is covered by writesADatasetLargerThanTheHeap.
+			Dataset declared = new WritableDatasetImpl(double.class, dimensions, "data", writableHdfFile,
+				DatasetCreationOptions.builder().chunkDimensions(1024, 1024, 1).build(),
+				chunkOffset -> new double[1024][1024]);
+
+			assertThat(declared.getSizeInBytes(), is(4L * 1024 * 1024 * 1024));
+
+			// The in memory path's limit is not asserted here: tripping it needs an array larger than
+			// Integer.MAX_VALUE bytes, which cannot be allocated, which is the reason the limit exists.
+
+			writableHdfFile.putDataset("placeholder", new int[]{1});
+		}
+		Files.deleteIfExists(file);
+	}
+
+	/**
+	 * Actually writes a dataset several times the size of the test JVM's heap, which is the only test that proves
+	 * the feature does what it claims. Opt in with {@code -Djhdf.test.largeWrite=true} because it is slow and
+	 * writes a multi gigabyte file.
+	 */
+	@Test
+	@EnabledIfSystemProperty(named = "jhdf.test.largeWrite", matches = "true")
+	void writesADatasetLargerThanTheHeap() throws Exception {
+		Path file = Files.createTempFile("largeWrite", ".hdf5");
+		try {
+			// 200x200 grid, 50 slices, 200 timepoints of doubles = 3.2 GB, VCell's export shape
+			int[] dimensions = {200, 200, 50, 200};
+			int[] chunkDimensions = {200, 200, 1, 1};
+
+			try (WritableHdfFile writableHdfFile = HdfFile.write(file)) {
+				writableHdfFile.putDataset("values", double.class, dimensions,
+					DatasetCreationOptions.builder().chunkDimensions(chunkDimensions).build(),
+					chunkOffset -> {
+						double[][][][] chunk = new double[200][200][1][1];
+						double value = chunkOffset[2] * 1000.0 + chunkOffset[3];
+						for (int x = 0; x < 200; x++) {
+							for (int y = 0; y < 200; y++) {
+								chunk[x][y][0][0] = value;
+							}
+						}
+						return chunk;
+					});
+			}
+
+			assertThat(Files.size(file) > 3_000_000_000L, is(true));
+
+			try (HdfFile hdfFile = new HdfFile(file)) {
+				Dataset dataset = hdfFile.getDatasetByPath("values");
+				assertThat(dataset.getDimensions(), is(dimensions));
+				// Spot check a slice rather than reading 3.2 GB back
+				double[][][][] slice =
+					(double[][][][]) dataset.getData(new long[]{0, 0, 17, 42}, new int[]{200, 200, 1, 1});
+				assertThat(slice[0][0][0][0], is(17_042.0));
+				assertThat(slice[199][199][0][0], is(17_042.0));
+			}
+		} finally {
+			Files.deleteIfExists(file);
+		}
+	}
+}


### PR DESCRIPTION
Towards #654. This is the first of two steps: supplying a chunked dataset's data one chunk at a time, so the dataset is never held in memory as a whole.

Thank you for the encouragement on the issue — happy to adjust anything here, including the API shape.

## Why this is a small change

`writeChunkedData` already does nearly all of it. It writes each chunk straight to the channel, keeps only `ChunkImpl(address, size, offset)` per chunk, and writes the fixed array index afterwards. And `WritableDatasetImpl.write` already emits a placeholder `DataLayoutMessage`, writes the payload, then swaps in the real message and rewrites the object header — so finalising a header after streaming the payload was already the established pattern.

The only thing forcing the whole dataset into memory was where the bytes came from:

```java
// Encode the full dataset into a flat row major buffer then slice it into chunks
final byte[] flatData = dataType.encodeData(data).array();
```

and the guard that exists purely because of it:

```java
if (dataSpace.getTotalLength() * dataType.getSize() > Integer.MAX_VALUE) {
    throw new HdfWritingException("Dataset is too large to write chunked...");
}
```

So the first commit is a pure refactor naming that dependency (`ChunkSource`), and the second supplies it from the caller instead.

## The API

```java
try (WritableHdfFile hdf = HdfFile.write(path)) {
    hdf.putDataset("values", double.class, new int[]{200, 200, 50, 200},
        DatasetCreationOptions.builder().chunkDimensions(200, 200, 1, 1).build(),
        chunkOffset -> readSlice(chunkOffset[2], chunkOffset[3]));   // one chunk
}
```

The shape and type are given rather than inferred, since there is no data object to infer them from. Internally both are derived from a one-element prototype array of the requested type and rank, so nothing proportional to the dataset is allocated.

Every chunk is requested exactly once. **A chunk that is never supplied fails the write** rather than being left as fill — a partially written dataset that reads back as zeros seemed worse than an error, but I am happy to make it fill instead if you would rather.

The per-dataset `Integer.MAX_VALUE` limit now applies only to the in-memory path, and its message points at `ChunkProvider`. The per-chunk limit is unchanged.

## Evidence

- **Byte-for-byte identical output.** For a dataset small enough to write both ways, the file produced from a `ChunkProvider` and the file produced from the whole array are identical — including with partial edge chunks, and with shuffle+deflate. That is what convinced me the type and dataspace derived from a prototype match the inferred ones.
- **`writesADatasetLargerThanTheHeap` writes 3.2 GB through a 512 MB heap** and reads a slice back. It is opt in via `-Djhdf.test.largeWrite=true` because it is slow and writes a multi gigabyte file; `build.gradle` forwards the property to the forked test JVM. (It silently skipped until I added that, which seemed worth fixing properly rather than working around.)
- Full suite green: 1440 tests, 0 failures.

The shape in that test is real: it is a VCell spatial-simulation export, 200×200 grid over 50 slices and 200 timepoints. VCell currently keeps a native HDF5 binding solely to write these incrementally, having moved all of its HDF5 *reading* to jhdf.

## Not in this PR

A push-style API (`writeChunk(offset, data)` as data arrives) is the other half of #654. It needs an allocation cursor in `WritableHdfFile.flush()`, which today lays out the whole tree in one pass from `ROOT_GROUP_ADDRESS`, plus a decision about what an unclosed streaming dataset means at file close. It seemed better reviewed on its own than bundled with the chunk-supply mechanics — but say the word if you would rather see them together.

One thing I noticed while writing it: `FixedArrayIndexWriter.createFixedArray` writes entries in `List` order and never reads `chunk.getOffset()`, so it relies on the caller building the list in chunk-index order. That holds for both paths here, but a push API supplying chunks out of order would need slots rather than appends.
